### PR TITLE
 Fix error parsing when uploading file

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -124,6 +124,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         subpath: e.g. v2 or iam/v1
         identity: e.g. assets/xxxxxxxxxxxxxxxxxxxxxxxxxxxx`
         fd: an iterable representing a file (usually from open())
+            the file must be opened in binary mode
         """
         response = requests.get(
             SEP.join((self.url, ROOT, subpath, identity)),
@@ -140,7 +141,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
             if chunk:
                 fd.write(chunk)
 
-        return response.json()
+        return response
 
     def post(self, path, request, *, headers=None):
         """
@@ -168,6 +169,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         path: e.g. v1/blobs
         fd: an iterable representing a file (usually from open())
+            the file must be opened in binary mode
         mtype: mime tiype (image/jpg)
         """
 

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -23,13 +23,14 @@ class _AttachmentsClient:
         )
 
     def download(self, identity, fd):
-        """docstring"""
-        return Attachment(
-            **self._archivist.get_file(
-                ATTACHMENTS_SUBPATH,
-                identity,
-                fd,
-            )
+        """
+        Note that returns the response as the body will be consumed by the
+        fd iterator
+        """
+        return self._archivist.get_file(
+            ATTACHMENTS_SUBPATH,
+            identity,
+            fd,
         )
 
 

--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -70,7 +70,7 @@ def __identity(response):
             except TypeError:
                 pass
             else:
-                identity = body.get('identity', "unknown")
+                identity = body.get("identity", "unknown")
 
     return identity
 

--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -63,8 +63,14 @@ def __identity(response):
         req = response.request
         body = getattr(req, "body", None)
         if body:
-            body = json.loads(body)
-            identity = body.get("identity", "unknown")
+            # when uploading a file the body attribute is a
+            # MultiPartEncoder
+            try:
+                body = json.loads(body)
+            except TypeError:
+                pass
+            else:
+                identity = body.get('identity', "unknown")
 
     return identity
 

--- a/unittests/testerrors.py
+++ b/unittests/testerrors.py
@@ -119,16 +119,17 @@ class TestErrors(TestCase):
         )
 
     def test_errors_403_multipartencoder(self):
-        '''
+        """
         Test errors
-        '''
+        """
+
         class Object:
             pass
 
         request = Object()
         request.body = MultipartEncoder(
             fields={
-                'file': ('filename', "filecontents", 'image/jpg'),
+                "file": ("filename", "filecontents", "image/jpg"),
             }
         )
         response = MockResponse(

--- a/unittests/testerrors.py
+++ b/unittests/testerrors.py
@@ -10,6 +10,8 @@ import json
 
 from unittest import TestCase
 
+from requests_toolbelt.multipart.encoder import MultipartEncoder
+
 from archivist.errors import (
     parse_response,
     Archivist4xxError,
@@ -37,6 +39,7 @@ class TestErrors(TestCase):
         """
         response = MockResponse(200)
         error = parse_response(response)
+
         self.assertEqual(
             error,
             None,
@@ -49,6 +52,7 @@ class TestErrors(TestCase):
         """
         response = MockResponse(300)
         error = parse_response(response)
+
         self.assertEqual(
             error,
             None,
@@ -61,12 +65,14 @@ class TestErrors(TestCase):
         """
         response = MockResponse(400, error="some error")
         error = parse_response(response)
+
         self.assertIsNotNone(
             error,
             msg="error should not be None",
         )
         with self.assertRaises(ArchivistBadRequestError) as ex:
             raise error
+
         self.assertEqual(
             str(ex.exception),
             '{"error": "some error"} (400)',
@@ -79,12 +85,14 @@ class TestErrors(TestCase):
         """
         response = MockResponse(401, error="some error")
         error = parse_response(response)
+
         self.assertIsNotNone(
             error,
             msg="error should not be None",
         )
         with self.assertRaises(ArchivistUnauthenticatedError) as ex:
             raise error
+
         self.assertEqual(
             str(ex.exception),
             '{"error": "some error"} (401)',
@@ -97,12 +105,45 @@ class TestErrors(TestCase):
         """
         response = MockResponse(403, error="some error")
         error = parse_response(response)
+
         self.assertIsNotNone(
             error,
             msg="error should not be None",
         )
         with self.assertRaises(ArchivistForbiddenError) as ex:
             raise error
+
+        self.assertEqual(
+            str(ex.exception),
+            '{"error": "some error"} (403)',
+        )
+
+    def test_errors_403_multipartencoder(self):
+        '''
+        Test errors
+        '''
+        class Object:
+            pass
+
+        request = Object()
+        request.body = MultipartEncoder(
+            fields={
+                'file': ('filename', "filecontents", 'image/jpg'),
+            }
+        )
+        response = MockResponse(
+            403,
+            request=request,
+            error="some error",
+        )
+        error = parse_response(response)
+        self.assertIsNotNone(
+            error,
+            msg="error should not be None",
+        )
+        with self.assertRaises(ArchivistForbiddenError) as ex:
+            raise error
+
         self.assertEqual(
             str(ex.exception),
             '{"error": "some error"} (403)',


### PR DESCRIPTION
When uploading a file the response.body is a 'MultipartEncoder' object. The parse_response function now handles this correctly if n error is encountered.

When downloading a file only the response is returned as the response.json() is consumed by the iter_content  method calls.