### PR TITLE
Fix minor typos

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -17,7 +17,7 @@
           "https://rkvst.poc.jitsuin.io",
           auth=authtoken,
       )
-      asset = arch.access_policies.create(...)
+      access_policy = arch.access_policies.create(...)
 
 """
 
@@ -32,6 +32,9 @@ from .constants import (
 
 from .assets import Asset
 
+#: Default page size - number of entities fetched in one REST GET in the
+#: :func:`~_AccessPoliciesClient.list` method. This can be overridden but should rarely
+#: be changed.
 DEFAULT_PAGE_SIZE = 500
 
 
@@ -182,7 +185,7 @@ class _AccessPoliciesClient:
     ):
         """List access policies.
 
-        List access policiess that match criteria.
+        List access policies that match criteria.
 
         Args:
             display_name (str): display name (optional0

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -7,7 +7,8 @@
 
    The REST methods in this class should only be used directly when
    a CRUD endpoint for the specific type of entity is unavaliable.
-   Current CRUD endpoints are assets, events, locations and attachments.
+   Current CRUD endpoints are assets, events, locations, attachments.
+   IAM subjects and IAM access policies.
 
    Instantiation of this class encapsulates the URL and authentication
    parameters:
@@ -23,8 +24,8 @@
           auth=authtoken,
       )
 
-    The arch variable now has additonal endpoints assets,events,locations and
-    attachments documented elsewhere.
+    The arch variable now has additonal endpoints assets,events,locations,
+    attachments, IAM subjects and IAM access policies documented elsewhere.
 
 """
 

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -30,8 +30,9 @@ from .constants import (
 from .confirm import wait_for_confirmation, wait_for_confirmed
 
 
-#: Default page size - number of entities fetched in one call to the
-#: :func:`~_AssetsClient.list` method.
+#: Default page size - number of entities fetched in one REST GET in the
+#: :func:`~_AssetsClient.list` method. This can be overridden but should rarely
+#: be changed.
 DEFAULT_PAGE_SIZE = 500
 
 

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -17,7 +17,8 @@
           "https://rkvst.poc.jitsuin.io",
           auth=authtoken,
       )
-      attachment = arch.attachments.create(...)
+      with open("something.jpg") as fd:
+          attachment = arch.attachments.upload(fd)
 
 """
 
@@ -46,7 +47,7 @@ class _AttachmentsClient:
         Creates attachment from opened file or other data source.
 
         Args:
-            fd (file): opened file escriptor or other file-type iterable.
+            fd (file): opened file descriptor or other file-type iterable.
             mtype (str): mimetype of data.
 
         Returns:

--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -8,7 +8,7 @@ import json
 
 
 class ArchivistError(Exception):
-    """Base exception fot=r archivist package"""
+    """Base exception for archivist package"""
 
 
 class ArchivistBadFieldError(ArchivistError):

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -33,8 +33,9 @@ from .constants import (
 from .confirm import wait_for_confirmation, wait_for_confirmed
 
 
-#: Default page size - number of entities fetched in one call to the
-#: :func:`~_EventsClient.list` method.
+#: Default page size - number of entities fetched in one REST GET in the
+#: :func:`~_EventsClient.list` method. This can be overridden but should rarely
+#: be changed.
 DEFAULT_PAGE_SIZE = 500
 
 

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -25,8 +25,9 @@
 from .constants import LOCATIONS_SUBPATH, LOCATIONS_LABEL
 
 
-#: Default page size - number of entities fetched in one call to the
-#: :func:`~_LocationsClient.list` method.
+#: Default page size - number of entities fetched in one REST GET in the
+#: :func:`~_LocationsClient.list` method. This can be overridden but should rarely
+#: be changed.
 DEFAULT_PAGE_SIZE = 500
 
 

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -17,7 +17,7 @@
           "https://rkvst.poc.jitsuin.io",
           auth=authtoken,
       )
-      asset = arch.subjects.create(...)
+      subject = arch.subjects.create(...)
 
 """
 
@@ -26,6 +26,9 @@ from .constants import (
     SUBJECTS_LABEL,
 )
 
+#: Default page size - number of entities fetched in one REST GET in the
+#: :func:`~_SubjectsClient.list` method. This can be overridden but should rarely
+#: be changed.
 DEFAULT_PAGE_SIZE = 500
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -27,4 +27,4 @@ REST api (in any language):
     *  fully unittested - 100% coverage.
     *  code style managed and enforced. 
 
-See the **examples/** directory for code that creates assets and events and lists them.
+See the **examples/** directory for example code.


### PR DESCRIPTION
Problem:
Spelling errors ...

Solution:
Fix spelling errors and some syntax errors in docs

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>