### PR TITLE
A type hinting for top level clients of Archivist 

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -31,6 +31,7 @@
 
 import json
 from os.path import isfile as os_path_isfile
+from typing import Optional
 
 from flatten_dict import flatten
 import requests
@@ -111,6 +112,11 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         self._events = None
         self._locations = None
         self._attachments = None
+
+        self.assets: Optional[_AssetsClient]
+        self.events: Optional[_EventsClient]
+        self.locations: Optional[_LocationsClient]
+        self.attachments: Optional[_AttachmentsClient]
 
     def __getattr__(self, value):
         """Create endpoints on demand"""

--- a/pylintrc
+++ b/pylintrc
@@ -139,12 +139,13 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        invalid-name, 
-        bad-classmethod-argument, 
-        bad-mcs-classmethod-argument, 
+        invalid-name,
+        bad-classmethod-argument,
+        bad-mcs-classmethod-argument,
         no-self-argument,
         bad-continuation,
-        bad-whitespace
+        bad-whitespace,
+        unsubscriptable-object,           # https://github.com/PyCQA/pylint/issues/3882 broken in 3.9
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -330,7 +331,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100 
+max-line-length=100
 
 # Maximum number of lines in a module.
 max-module-lines=1000


### PR DESCRIPTION
**Problem**: IDE's cannot recognise the top-level clients for Archivist, therefore IntelliSense does not work.
**Solution**: Add type hinting for the top-level clients