### PR TITLE
Remove unused behaviours

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ attrs = {
         "some_custom_attribute": "value"  # You can add any custom value as long as
                                       # it does not start with arc_
 }
-behaviours = ["Attachments", "Firmware", "LocationUpdate", "Maintenance", "RecordEvidence"]
+behaviours = ["Attachments", "RecordEvidence"]
 
 # The first argument is the behaviours of the asset
 # The second argument is the attributes of the asset

--- a/examples/access_policy_create.py
+++ b/examples/access_policy_create.py
@@ -54,7 +54,7 @@ def main():
         {
             "asset_attributes_read": ["toner_colour", "toner_type"],
             "asset_attributes_write": ["toner_colour"],
-            "behaviours": ["Attachments", "Firmware", "Maintenance", "RecordEvidence"],
+            "behaviours": ["Attachments", "RecordEvidence"],
             "event_arc_display_type_read": ["toner_type", "toner_colour"],
             "event_arc_display_type_write": ["toner_replacement"],
             "include_attributes": [

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -37,9 +37,6 @@ def create_asset(arch):
     }
     behaviours = [
         "Attachments",
-        "Firmware",
-        "LocationUpdate",
-        "Maintenance",
         "RecordEvidence",
     ]
 

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -82,9 +82,6 @@ def create_asset(arch):
     }
     behaviours = [
         "Attachments",
-        "Firmware",
-        "LocationUpdate",
-        "Maintenance",
         "RecordEvidence",
     ]
 

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -44,7 +44,7 @@ ACCESS_PERMISSIONS = [
             "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
             "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d",
         ],
-        "behaviours": ["Attachments", "Firmware", "Maintenance", "RecordEvidence"],
+        "behaviours": ["Attachments", "RecordEvidence"],
         "include_attributes": [
             "arc_display_name",
             "arc_display_type",

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -54,7 +54,7 @@ ACCESS_PERMISSIONS = [
             "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
             "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d",
         ],
-        "behaviours": ["Attachments", "Firmware", "Maintenance", "RecordEvidence"],
+        "behaviours": ["Attachments", "RecordEvidence"],
         "include_attributes": [
             "arc_display_name",
             "arc_display_type",

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -25,10 +25,7 @@ from .mock_response import MockResponse
 
 
 BEHAVIOURS = [
-    "Firmware",
-    "Maintenance",
     "RecordEvidence",
-    "LocationUpdate",
     "Attachments",
 ]
 PRIMARY_IMAGE = {


### PR DESCRIPTION
Problem:
Some defined behaviours have been removed from archivist.

Solution:
"Firmware", "Maintenance", "LocationUpdate" and "UserAttributes"
behaviours removed from examples and tests.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>