### PR TITLE
Fix type hinting to match Pylance "basic" type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ htmlcov/
 .cache/
 .eggs/
 .task/
+*.pyi
+.vscode

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,7 @@ tasks:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
       - docker build --no-cache --build-arg VERSION=3.8 -f Dockerfile-builder -t jitsuin-archivist-python-builder .
-  
+
   builder-3.9:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
@@ -46,13 +46,13 @@ tasks:
   docs:
     desc: Create sphinx documentation
     deps: [about]
-    cmds: 
+    cmds:
       - ./scripts/builder.sh /bin/bash -c "cd docs && make html"
 
   format:
     desc: Format code using black
     deps: [about]
-    cmds: 
+    cmds:
       - ./scripts/builder.sh black archivist examples functests unittests
 
   functests:
@@ -60,9 +60,9 @@ tasks:
     deps: [about]
     cmds:
       - ./scripts/builder.sh ./scripts/functests.sh
-  
+
   publish:
-    desc: pubish wheel package (will require username and password)
+    desc: publish wheel package (will require username and password)
     deps: [about]
     cmds:
       - ./scripts/builder.sh python3 -m twine upload --repository pypi dist/*
@@ -72,12 +72,12 @@ tasks:
     deps: [about]
     cmds:
       - ./scripts/builder.sh ./scripts/unittests.sh
-  
+
   wheel:
     desc: Builds python wheel package
     deps: [about]
     cmds:
       - rm -rf *egg-info
-      - rm -rf build 
+      - rm -rf build
       - rm -f dist/*
       - python3 setup.py bdist_wheel

--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -21,7 +21,7 @@
 
 """
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 import logging
 from copy import deepcopy
 
@@ -65,7 +65,7 @@ class _AccessPoliciesClient:
         self._archivist = archivist
 
     def create(
-        self, props: dict, filters: List, access_permissions: List
+        self, props: Dict, filters: List, access_permissions: List
     ) -> AccessPolicy:
         """Create access policy
 
@@ -85,7 +85,7 @@ class _AccessPoliciesClient:
             self.__query(props, filters=filters, access_permissions=access_permissions),
         )
 
-    def create_from_data(self, data: dict) -> AccessPolicy:
+    def create_from_data(self, data: Dict) -> AccessPolicy:
         """Create access policy
 
         Creates access policy with request body from data stream.
@@ -127,9 +127,9 @@ class _AccessPoliciesClient:
     def update(
         self,
         identity,
-        props: Optional[dict] = None,
-        filters: Optional[list] = None,
-        access_permissions: Optional[list] = None,
+        props: Optional[Dict] = None,
+        filters: Optional[List] = None,
+        access_permissions: Optional[List] = None,
     ) -> AccessPolicy:
         """Update Access Policy
 
@@ -155,7 +155,7 @@ class _AccessPoliciesClient:
             )
         )
 
-    def delete(self, identity: str) -> dict:
+    def delete(self, identity: str) -> Dict:
         """Delete Access Policy
 
         Deletes access policy.
@@ -170,7 +170,12 @@ class _AccessPoliciesClient:
         return self._archivist.delete(ACCESS_POLICIES_SUBPATH, identity)
 
     @staticmethod
-    def __query(props, *, filters=None, access_permissions=None):
+    def __query(
+        props: Optional[Dict],
+        *,
+        filters: Optional[List] = None,
+        access_permissions: Optional[List] = None,
+    ) -> Dict:
         query = deepcopy(props) if props else {}
         if filters is not None:
             query["filters"] = filters

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -22,8 +22,9 @@
 """
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 from copy import deepcopy
+from archivist.type_aliases import NoneOnError
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
@@ -53,7 +54,7 @@ class Asset(dict):
     """
 
     @property
-    def primary_image(self):
+    def primary_image(self) -> NoneOnError[str]:
         """Primary Image
 
         Attachment that is the primary image of the asset.
@@ -80,7 +81,7 @@ class Asset(dict):
         return None
 
     @property
-    def name(self):
+    def name(self) -> NoneOnError[str]:
         """str: name of the asset"""
         try:
             name = self["attributes"]["arc_display_name"]
@@ -106,7 +107,9 @@ class _AssetsClient:
     def __init__(self, archivist: "type_helper.Archivist"):
         self._archivist = archivist
 
-    def create(self, behaviours: List, attrs: dict, *, confirm: bool = False) -> Asset:
+    def create(
+        self, behaviours: List, attrs: Dict, *, confirm: bool = False
+    ) -> NoneOnError[Asset]:
         """Create asset
 
         Creates asset with defined behaviours and attributes.
@@ -129,7 +132,9 @@ class _AssetsClient:
             confirm=confirm,
         )
 
-    def create_from_data(self, data: dict, *, confirm: bool = False) -> Asset:
+    def create_from_data(
+        self, data: Dict, *, confirm: bool = False
+    ) -> NoneOnError[Asset]:
         """Create asset
 
         Creates asset with request body from data stream.
@@ -169,7 +174,7 @@ class _AssetsClient:
         return Asset(**self._archivist.get(ASSETS_SUBPATH, identity))
 
     @staticmethod
-    def __query(props, attrs):
+    def __query(props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
         query = deepcopy(props) if props else {}
         if attrs:
             query["attributes"] = attrs
@@ -177,7 +182,7 @@ class _AssetsClient:
         return query
 
     def count(
-        self, *, props: Optional[dict] = None, attrs: Optional[dict] = None
+        self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
     ) -> int:
         """Count assets.
 
@@ -196,7 +201,7 @@ class _AssetsClient:
         )
 
     def wait_for_confirmed(
-        self, *, props: Optional[dict] = None, attrs: Optional[dict] = None
+        self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
     ) -> bool:
         """Wait for assets to be confirmed.
 
@@ -216,8 +221,8 @@ class _AssetsClient:
         self,
         *,
         page_size: int = DEFAULT_PAGE_SIZE,
-        props: Optional[dict] = None,
-        attrs: Optional[dict] = None,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
     ):
         """List assets.
 
@@ -243,7 +248,7 @@ class _AssetsClient:
         )
 
     def read_by_signature(
-        self, *, props: Optional[dict] = None, attrs: Optional[dict] = None
+        self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
     ) -> Asset:
         """Read Asset by signature.
 

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -24,7 +24,7 @@
 
 # pylint:disable=too-few-public-methods
 
-from typing import IO
+from typing import BinaryIO
 import logging
 
 from requests.models import Response
@@ -60,7 +60,7 @@ class _AttachmentsClient:
     def __init__(self, archivist: "type_helper.Archivist"):
         self._archivist = archivist
 
-    def upload(self, fd: IO, *, mtype: str = "image/jpg") -> Attachment:
+    def upload(self, fd: BinaryIO, *, mtype: str = "image/jpg") -> Attachment:
         """Create attachment
 
         Creates attachment from opened file or other data source.
@@ -83,7 +83,7 @@ class _AttachmentsClient:
             )
         )
 
-    def download(self, identity: str, fd: IO) -> Response:
+    def download(self, identity: str, fd: BinaryIO) -> Response:
         """Read attachment
 
         Reads attachment into data sink (usually a file opened for write)..

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -23,8 +23,9 @@
 """
 
 import logging
-from typing import Optional
+from typing import Dict, Optional
 from copy import deepcopy
+from archivist.type_aliases import NoneOnError
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
@@ -119,12 +120,12 @@ class _EventsClient:
     def create(
         self,
         asset_id: str,
-        props: dict,
-        attrs: dict,
+        props: Dict,
+        attrs: Dict,
         *,
-        asset_attrs: Optional[dict] = None,
+        asset_attrs: Optional[Dict] = None,
         confirm: bool = False,
-    ) -> Event:
+    ) -> NoneOnError[Event]:
         """Create event
 
         Creates event for given asset.
@@ -148,7 +149,9 @@ class _EventsClient:
             confirm=confirm,
         )
 
-    def create_from_data(self, asset_id: str, data: dict, *, confirm=False) -> Event:
+    def create_from_data(
+        self, asset_id: str, data: Dict, *, confirm=False
+    ) -> NoneOnError[Event]:
         """Create event
 
         Creates event for given asset from data.
@@ -194,7 +197,9 @@ class _EventsClient:
         )
 
     @staticmethod
-    def __query(props, attrs, asset_attrs):
+    def __query(
+        props: Optional[Dict], attrs: Optional[Dict], asset_attrs: Optional[Dict]
+    ) -> Dict:
         query = deepcopy(props) if props else {}
         if attrs:
             query["event_attributes"] = attrs
@@ -207,9 +212,9 @@ class _EventsClient:
         self,
         *,
         asset_id: str = ASSETS_WILDCARD,
-        props: Optional[dict] = None,
-        attrs: Optional[dict] = None,
-        asset_attrs: Optional[dict] = None,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
+        asset_attrs: Optional[Dict] = None,
     ) -> int:
         """Count events.
 
@@ -235,9 +240,9 @@ class _EventsClient:
         self,
         *,
         asset_id: str = ASSETS_WILDCARD,
-        props: Optional[dict] = None,
-        attrs: Optional[dict] = None,
-        asset_attrs: Optional[dict] = None,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
+        asset_attrs: Optional[Dict] = None,
     ) -> bool:
         """Wait for events to be confirmed.
 
@@ -262,9 +267,9 @@ class _EventsClient:
         *,
         asset_id: str = ASSETS_WILDCARD,
         page_size: int = DEFAULT_PAGE_SIZE,
-        props: Optional[dict] = None,
-        attrs: Optional[dict] = None,
-        asset_attrs: Optional[dict] = None,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
+        asset_attrs: Optional[Dict] = None,
     ):
         """List events.
 
@@ -295,9 +300,9 @@ class _EventsClient:
         self,
         *,
         asset_id: str = ASSETS_WILDCARD,
-        props: Optional[dict] = None,
-        attrs: Optional[dict] = None,
-        asset_attrs: Optional[dict] = None,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
+        asset_attrs: Optional[Dict] = None,
     ) -> Event:
         """Read event by signature.
 

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -23,7 +23,7 @@
 """
 
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
@@ -62,7 +62,7 @@ class _LocationsClient:
     def __init__(self, archivist: "type_helper.Archivist"):
         self._archivist = archivist
 
-    def create(self, props: dict, *, attrs: Optional[dict] = None) -> Location:
+    def create(self, props: Dict, *, attrs: Optional[Dict] = None) -> Location:
         """Create location
 
         Creates location with defined properties and attributes.
@@ -78,7 +78,7 @@ class _LocationsClient:
         LOGGER.debug("Create Location %s", props)
         return self.create_from_data(self.__query(props, attrs))
 
-    def create_from_data(self, data: dict) -> Location:
+    def create_from_data(self, data: Dict) -> Location:
         """Create location
 
         Creates location with request body from data stream.
@@ -118,7 +118,7 @@ class _LocationsClient:
         )
 
     @staticmethod
-    def __query(props, attrs):
+    def __query(props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
         query = props or {}
         if attrs:
             query["attributes"] = attrs
@@ -126,7 +126,7 @@ class _LocationsClient:
         return query
 
     def count(
-        self, *, props: Optional[dict] = None, attrs: Optional[dict] = None
+        self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
     ) -> int:
         """Count locations.
 
@@ -148,8 +148,8 @@ class _LocationsClient:
         self,
         *,
         page_size: int = DEFAULT_PAGE_SIZE,
-        props: Optional[dict] = None,
-        attrs: Optional[dict] = None,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
     ):
         """List locations.
 
@@ -176,7 +176,7 @@ class _LocationsClient:
         )
 
     def read_by_signature(
-        self, *, props: Optional[dict] = None, attrs: Optional[dict] = None
+        self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
     ) -> Location:
         """Read location by signature.
 

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -22,7 +22,7 @@
 """
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
@@ -84,7 +84,7 @@ class _SubjectsClient:
             ),
         )
 
-    def create_from_data(self, data: dict) -> Subject:
+    def create_from_data(self, data: Dict) -> Subject:
         """Create subject
 
         Creates subject with request body from data stream.
@@ -127,9 +127,9 @@ class _SubjectsClient:
         self,
         identity: str,
         *,
-        display_name: Optional[dict] = None,
-        wallet_pub_keys: Optional[dict] = None,
-        tessera_pub_keys: Optional[dict] = None,
+        display_name: str = None,
+        wallet_pub_keys: Optional[List[str]] = None,
+        tessera_pub_keys: Optional[List[str]] = None,
     ) -> Subject:
         """Update Subject
 
@@ -157,7 +157,7 @@ class _SubjectsClient:
             )
         )
 
-    def delete(self, identity: str):
+    def delete(self, identity: str) -> Dict:
         """Delete Subject
 
         Deletes subject.
@@ -172,7 +172,13 @@ class _SubjectsClient:
         return self._archivist.delete(SUBJECTS_SUBPATH, identity)
 
     @staticmethod
-    def __query(*, display_name=None, wallet_pub_keys=None, tessera_pub_keys=None):
+    def __query(
+        *,
+        display_name: Optional[str] = None,
+        wallet_pub_keys: Optional[List[str]] = None,
+        tessera_pub_keys: Optional[List[str]] = None,
+    ) -> Dict:
+
         query = {}
 
         if display_name is not None:

--- a/archivist/type_aliases.py
+++ b/archivist/type_aliases.py
@@ -1,0 +1,13 @@
+""" Type aliases used for identifying complex input and return types for RKVST
+
+TODO: Create more explicit type aliases, Current type aliases default to
+Dict[Unknown, Unknown] and List[Unknown].  Minimising the potential effectiveness of
+the type hinting.
+
+- Look at TypedDict for explicit formatting of dictionaries
+"""
+
+from typing import Optional
+
+NoneOnError = Optional
+"""Means the function returns None if a Error occurs upstream"""


### PR DESCRIPTION
Problem: 
The "Basic" type checking level from Pylance notified multiple errors

Solution: 
Add the correct type hinting, and ignore type comments to deal with all Pylance errors

Signed off: Serhiy <serhiy1@live.co.uk>