### PR TITLE
Add Ring buffer to store last 10 response objects

### DIFF
--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -308,6 +308,16 @@ class TestArchivistGet(TestArchivistMethods):
         )
 
     @mock.patch("requests.get")
+    def test_ring_buffer(self, mock_get):
+        """
+        Test That the ring buffer for response objects works as expected
+        """
+        mock_get.return_value = MockResponse(200)
+        resp = self.arch.get("path/path", "entity/xxxxxxxx")
+        last_response = self.arch.last_response()
+        self.assertEqual(last_response, [mock_get.return_value])
+
+    @mock.patch("requests.get")
     def test_get_with_error(self, mock_get):
         """
         Test get method with error


### PR DESCRIPTION
Problem: 
Currently, response objects are not accessible through the SDK, making certain actions , like checking header data, impossible to do from the user side.

Solution: 
Store the last 10 response objects in a ring buffer and provide a function in archivist to retrieve  a user selected amount

Signed off: 
Serhiy: <Serhiy1@live.co.uk>