### PR TITLE
Fix misleading None on Error type hint  

### DIFF
--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -107,9 +107,7 @@ class _AssetsClient:
     def __init__(self, archivist: "type_helper.Archivist"):
         self._archivist = archivist
 
-    def create(
-        self, behaviours: List, attrs: Dict, *, confirm: bool = False
-    ) -> Asset:
+    def create(self, behaviours: List, attrs: Dict, *, confirm: bool = False) -> Asset:
         """Create asset
 
         Creates asset with defined behaviours and attributes.
@@ -132,9 +130,7 @@ class _AssetsClient:
             confirm=confirm,
         )
 
-    def create_from_data(
-        self, data: Dict, *, confirm: bool = False
-    ) -> Asset:
+    def create_from_data(self, data: Dict, *, confirm: bool = False) -> Asset:
         """Create asset
 
         Creates asset with request body from data stream.
@@ -157,7 +153,7 @@ class _AssetsClient:
         if not confirm:
             return asset
 
-        return wait_for_confirmation(self, asset["identity"])   # type: ignore  The None return is unreachable
+        return wait_for_confirmation(self, asset["identity"])  # type: ignore
 
     def read(self, identity: str) -> Asset:
         """Read asset

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -109,7 +109,7 @@ class _AssetsClient:
 
     def create(
         self, behaviours: List, attrs: Dict, *, confirm: bool = False
-    ) -> NoneOnError[Asset]:
+    ) -> Asset:
         """Create asset
 
         Creates asset with defined behaviours and attributes.
@@ -134,7 +134,7 @@ class _AssetsClient:
 
     def create_from_data(
         self, data: Dict, *, confirm: bool = False
-    ) -> NoneOnError[Asset]:
+    ) -> Asset:
         """Create asset
 
         Creates asset with request body from data stream.
@@ -157,7 +157,7 @@ class _AssetsClient:
         if not confirm:
             return asset
 
-        return wait_for_confirmation(self, asset["identity"])
+        return wait_for_confirmation(self, asset["identity"])   # type: ignore  The None return is unreachable
 
     def read(self, identity: str) -> Asset:
         """Read asset

--- a/archivist/confirm.py
+++ b/archivist/confirm.py
@@ -67,7 +67,10 @@ def wait_for_confirmation(self, identity):
     if entity[CONFIRMATION_STATUS] == CONFIRMATION_CONFIRMED:
         return entity
 
-    return None
+    return None  # this line is unreachable to function that use it
+    # But will mess up any linters that use type hints
+    # Remember to ignore the return type if you use this
+    # Function
 
 
 def __on_giveup_confirmed(details):

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -25,7 +25,6 @@
 import logging
 from typing import Dict, Optional
 from copy import deepcopy
-from archivist.type_aliases import NoneOnError
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
@@ -125,7 +124,7 @@ class _EventsClient:
         *,
         asset_attrs: Optional[Dict] = None,
         confirm: bool = False,
-    ) -> NoneOnError[Event]:
+    ) -> Event:
         """Create event
 
         Creates event for given asset.
@@ -151,7 +150,7 @@ class _EventsClient:
 
     def create_from_data(
         self, asset_id: str, data: Dict, *, confirm=False
-    ) -> NoneOnError[Event]:
+    ) -> Event:
         """Create event
 
         Creates event for given asset from data.
@@ -175,7 +174,7 @@ class _EventsClient:
         if not confirm:
             return event
 
-        return wait_for_confirmation(self, event["identity"])
+        return wait_for_confirmation(self, event["identity"])   # type: ignore  The None return is unreachable
 
     def read(self, identity: str) -> Event:
         """Read event

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -148,9 +148,7 @@ class _EventsClient:
             confirm=confirm,
         )
 
-    def create_from_data(
-        self, asset_id: str, data: Dict, *, confirm=False
-    ) -> Event:
+    def create_from_data(self, asset_id: str, data: Dict, *, confirm=False) -> Event:
         """Create event
 
         Creates event for given asset from data.
@@ -174,7 +172,7 @@ class _EventsClient:
         if not confirm:
             return event
 
-        return wait_for_confirmation(self, event["identity"])   # type: ignore  The None return is unreachable
+        return wait_for_confirmation(self, event["identity"])  # type: ignore
 
     def read(self, identity: str) -> Event:
         """Read event


### PR DESCRIPTION
Problem: The function `wait_for_confirmation()` has an unreachable "return None" (for consumers of the function) . Pylance cannot prove that the return is unreachable due to the use of decorators and provides an erroneous type hint error. 

Solution: 
Use PEP 484 annotation to ignore the returned type and fix previous type hints.  

Signed off:
Serhiy: Serhiy1@live.co.uk