### PR TITLE
Unittests mock sessions method inplace

### DIFF
--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -22,6 +22,7 @@ from .testassets import RESPONSE as ASSET
 
 
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 # pylint: disable=unused-variable
 
 PROPS = {
@@ -93,228 +94,50 @@ class TestAccessPolicies(TestCase):
     def setUp(self):
         self.arch = Archivist("url", auth="authauthauth")
 
-    @mock.patch("requests.Session.post")
-    def test_access_policies_create(self, mock_post):
+    def test_access_policies_create(self):
         """
         Test access_policy creation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
 
-        access_policy = self.arch.access_policies.create(
-            PROPS, FILTERS, ACCESS_PERMISSIONS
-        )
-        self.assertEqual(
-            tuple(mock_post.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}"),),
-                {
-                    "data": REQUEST_DATA,
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="CREATE method called incorrectly",
-        )
-        self.assertEqual(
-            access_policy,
-            RESPONSE,
-            msg="CREATE method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_read(self, mock_get):
-        """
-        Test access_policy reading
-        """
-        mock_get.return_value = MockResponse(200, **RESPONSE)
-
-        access_policy = self.arch.access_policies.read(IDENTITY)
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.delete")
-    def test_access_policies_delete(self, mock_delete):
-        """
-        Test access_policy deleting
-        """
-        mock_delete.return_value = MockResponse(200, {})
-
-        access_policy = self.arch.access_policies.delete(IDENTITY)
-        self.assertEqual(
-            tuple(mock_delete.call_args),
-            (
-                ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="DELETE method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.patch")
-    def test_access_policies_update(self, mock_patch):
-        """
-        Test access_policy deleting
-        """
-        mock_patch.return_value = MockResponse(200, **RESPONSE)
-
-        access_policy = self.arch.access_policies.update(
-            IDENTITY,
-            PROPS,
-        )
-        self.assertEqual(
-            tuple(mock_patch.call_args),
-            (
-                ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
-                {
-                    "data": UPDATE_DATA,
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="PATCH method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_read_with_error(self, mock_get):
-        """
-        Test read method with error
-        """
-        mock_get.return_value = MockResponse(400)
-        with self.assertRaises(ArchivistBadRequestError):
-            resp = self.arch.access_policies.read(IDENTITY)
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_count(self, mock_get):
-        """
-        Test access_policy counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            access_policies=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.access_policies.count()
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-        self.assertEqual(
-            count,
-            1,
-            msg="Incorrect count",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_count_by_name(self, mock_get):
-        """
-        Test access_policy counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            access_policies=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.access_policies.count(
-            display_name="Policy display name",
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
+            access_policy = self.arch.access_policies.create(
+                PROPS, FILTERS, ACCESS_PERMISSIONS
+            )
+            self.assertEqual(
+                tuple(mock_post.call_args),
                 (
-                    (
-                        f"url/{ROOT}/{SUBPATH}"
-                        "?page_size=1"
-                        "&display_name=Policy display name"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
+                    ((f"url/{ROOT}/{SUBPATH}"),),
+                    {
+                        "data": REQUEST_DATA,
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_list(self, mock_get):
-        """
-        Test access_policy listing
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            access_policies=[
-                RESPONSE,
-            ],
-        )
-
-        access_policies = list(self.arch.access_policies.list())
-        self.assertEqual(
-            len(access_policies),
-            1,
-            msg="incorrect number of access_policies",
-        )
-        for access_policy in access_policies:
+                ),
+                msg="CREATE method called incorrectly",
+            )
             self.assertEqual(
                 access_policy,
                 RESPONSE,
-                msg="Incorrect access_policy listed",
+                msg="CREATE method called incorrectly",
             )
 
-        for a in mock_get.call_args_list:
+    def test_access_policies_read(self):
+        """
+        Test access_policy reading
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+
+            access_policy = self.arch.access_policies.read(IDENTITY)
             self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                    ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
                             "content-type": "application/json",
@@ -327,43 +150,126 @@ class TestAccessPolicies(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_access_policies_list_by_name(self, mock_get):
+    def test_access_policies_delete(self):
         """
-        Test access_policy listing
+        Test access_policy deleting
         """
-        mock_get.return_value = MockResponse(
-            200,
-            access_policies=[
-                RESPONSE,
-            ],
-        )
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200, {})
 
-        access_policies = list(
-            self.arch.access_policies.list(
+            access_policy = self.arch.access_policies.delete(IDENTITY)
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )
+
+    def test_access_policies_update(self):
+        """
+        Test access_policy deleting
+        """
+        with mock.patch.object(self.arch._session, "patch") as mock_patch:
+            mock_patch.return_value = MockResponse(200, **RESPONSE)
+
+            access_policy = self.arch.access_policies.update(
+                IDENTITY,
+                PROPS,
+            )
+            self.assertEqual(
+                tuple(mock_patch.call_args),
+                (
+                    ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
+                    {
+                        "data": UPDATE_DATA,
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="PATCH method called incorrectly",
+            )
+
+    def test_access_policies_read_with_error(self):
+        """
+        Test read method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(400)
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.access_policies.read(IDENTITY)
+
+    def test_access_policies_count(self):
+        """
+        Test access_policy counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                access_policies=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.access_policies.count()
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+            self.assertEqual(
+                count,
+                1,
+                msg="Incorrect count",
+            )
+
+    def test_access_policies_count_by_name(self):
+        """
+        Test access_policy counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                access_policies=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.access_policies.count(
                 display_name="Policy display name",
             )
-        )
-        self.assertEqual(
-            len(access_policies),
-            1,
-            msg="incorrect number of access_policies",
-        )
-        for access_policy in access_policies:
             self.assertEqual(
-                access_policy,
-                RESPONSE,
-                msg="Incorrect access_policy listed",
-            )
-
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
                     (
                         (
                             f"url/{ROOT}/{SUBPATH}"
-                            f"?page_size={DEFAULT_PAGE_SIZE}"
+                            "?page_size=1"
                             "&display_name=Policy display name"
                         ),
                     ),
@@ -371,6 +277,7 @@ class TestAccessPolicies(TestCase):
                         "headers": {
                             "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
                         "verify": True,
                         "cert": None,
@@ -379,86 +286,129 @@ class TestAccessPolicies(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_access_policies_count_matching_access_policies(self, mock_get):
+    def test_access_policies_list(self):
         """
-        Test access_policy counting
+        Test access_policy listing
         """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            access_policies=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.access_policies.count_matching_access_policies(ASSET_ID)
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (
-                    (
-                        f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
-                        "?page_size=1"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-        self.assertEqual(
-            count,
-            1,
-            msg="Incorrect count",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_list_matching_access_policies(self, mock_get):
-        """
-        Test access_policy counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            access_policies=[
-                RESPONSE,
-            ],
-        )
-        access_policies = list(
-            self.arch.access_policies.list_matching_access_policies(ASSET_ID)
-        )
-        self.assertEqual(
-            len(access_policies),
-            1,
-            msg="incorrect number of access_policies",
-        )
-        for access_policy in access_policies:
-            self.assertEqual(
-                access_policy,
-                RESPONSE,
-                msg="Incorrect access_policy listed",
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                access_policies=[
+                    RESPONSE,
+                ],
             )
 
-        for a in mock_get.call_args_list:
+            access_policies = list(self.arch.access_policies.list())
             self.assertEqual(
-                tuple(a),
+                len(access_policies),
+                1,
+                msg="incorrect number of access_policies",
+            )
+            for access_policy in access_policies:
+                self.assertEqual(
+                    access_policy,
+                    RESPONSE,
+                    msg="Incorrect access_policy listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_access_policies_list_by_name(self):
+        """
+        Test access_policy listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                access_policies=[
+                    RESPONSE,
+                ],
+            )
+
+            access_policies = list(
+                self.arch.access_policies.list(
+                    display_name="Policy display name",
+                )
+            )
+            self.assertEqual(
+                len(access_policies),
+                1,
+                msg="incorrect number of access_policies",
+            )
+            for access_policy in access_policies:
+                self.assertEqual(
+                    access_policy,
+                    RESPONSE,
+                    msg="Incorrect access_policy listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            (
+                                f"url/{ROOT}/{SUBPATH}"
+                                f"?page_size={DEFAULT_PAGE_SIZE}"
+                                "&display_name=Policy display name"
+                            ),
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_access_policies_count_matching_access_policies(self):
+        """
+        Test access_policy counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                access_policies=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.access_policies.count_matching_access_policies(ASSET_ID)
+            self.assertEqual(
+                tuple(mock_get.call_args),
                 (
                     (
-                        f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
-                        f"?page_size={DEFAULT_PAGE_SIZE}",
+                        (
+                            f"url/{ROOT}/"
+                            f"{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
+                            "?page_size=1"
+                        ),
                     ),
                     {
                         "headers": {
                             "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
                         "verify": True,
                         "cert": None,
@@ -466,85 +416,88 @@ class TestAccessPolicies(TestCase):
                 ),
                 msg="GET method called incorrectly",
             )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_count_matching_assets(self, mock_get):
-        """
-        Test access_policy counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            assets=[
-                ASSET,
-            ],
-        )
-
-        count = self.arch.access_policies.count_matching_assets(IDENTITY)
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (
-                    (
-                        f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
-                        "?page_size=1"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-        self.assertEqual(
-            count,
-            1,
-            msg="Incorrect count",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_access_policies_list_matching_assets(self, mock_get):
-        """
-        Test access_policy counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            assets=[
-                ASSET,
-            ],
-        )
-        assets = list(self.arch.access_policies.list_matching_assets(IDENTITY))
-        self.assertEqual(
-            len(assets),
-            1,
-            msg="incorrect number of assets",
-        )
-        for asset in assets:
             self.assertEqual(
-                asset,
-                ASSET,
-                msg="Incorrect asset listed",
+                count,
+                1,
+                msg="Incorrect count",
             )
 
-        for a in mock_get.call_args_list:
+    def test_access_policies_list_matching_access_policies(self):
+        """
+        Test access_policy counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                access_policies=[
+                    RESPONSE,
+                ],
+            )
+            access_policies = list(
+                self.arch.access_policies.list_matching_access_policies(ASSET_ID)
+            )
             self.assertEqual(
-                tuple(a),
+                len(access_policies),
+                1,
+                msg="incorrect number of access_policies",
+            )
+            for access_policy in access_policies:
+                self.assertEqual(
+                    access_policy,
+                    RESPONSE,
+                    msg="Incorrect access_policy listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            f"url/{ROOT}/"
+                            f"{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
+                            f"?page_size={DEFAULT_PAGE_SIZE}",
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_access_policies_count_matching_assets(self):
+        """
+        Test access_policy counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                assets=[
+                    ASSET,
+                ],
+            )
+
+            count = self.arch.access_policies.count_matching_assets(IDENTITY)
+            self.assertEqual(
+                tuple(mock_get.call_args),
                 (
                     (
-                        f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
-                        f"?page_size={DEFAULT_PAGE_SIZE}",
+                        (
+                            f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
+                            "?page_size=1"
+                        ),
                     ),
                     {
                         "headers": {
                             "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
                         "verify": True,
                         "cert": None,
@@ -552,3 +505,53 @@ class TestAccessPolicies(TestCase):
                 ),
                 msg="GET method called incorrectly",
             )
+            self.assertEqual(
+                count,
+                1,
+                msg="Incorrect count",
+            )
+
+    def test_access_policies_list_matching_assets(self):
+        """
+        Test access_policy counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                assets=[
+                    ASSET,
+                ],
+            )
+            assets = list(self.arch.access_policies.list_matching_assets(IDENTITY))
+            self.assertEqual(
+                len(assets),
+                1,
+                msg="incorrect number of assets",
+            )
+            for asset in assets:
+                self.assertEqual(
+                    asset,
+                    ASSET,
+                    msg="Incorrect asset listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
+                            f"?page_size={DEFAULT_PAGE_SIZE}",
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -20,6 +20,7 @@ from .mock_response import MockResponse
 
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 
 
 class TestArchivist(TestCase):
@@ -137,146 +138,146 @@ class TestArchivistPost(TestArchivistMethods):
     Test Archivist POST method
     """
 
-    @mock.patch("requests.Session.post")
-    def test_post(self, mock_post):
+    def test_post(self):
         """
         Test default post method
         """
         request = {"field1": "value1"}
-        mock_post.return_value = MockResponse(200, request=request)
-        resp = self.arch.post("path/path", request)
-        self.assertEqual(
-            tuple(mock_post.call_args),
-            (
-                (f"url/{ROOT}/path/path",),
-                {
-                    "data": '{"field1": "value1"}',
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, request=request)
+            resp = self.arch.post("path/path", request)
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    (f"url/{ROOT}/path/path",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="POST method called incorrectly",
-        )
+                ),
+                msg="POST method called incorrectly",
+            )
 
-    @mock.patch("requests.Session.post")
-    def test_post_with_error(self, mock_post):
+    def test_post_with_error(self):
         """
         Test post method with error
         """
         request = {"field1": "value1"}
-        mock_post.return_value = MockResponse(400, request=request, field1="value1")
-        with self.assertRaises(ArchivistBadRequestError):
-            resp = self.arch.post("path/path", request)
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(400, request=request, field1="value1")
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.post("path/path", request)
 
-    @mock.patch("requests.Session.post")
-    def test_post_with_headers(self, mock_post):
+    def test_post_with_headers(self):
         """
         Test default post method
         """
         request = {"field1": "value1"}
-        mock_post.return_value = MockResponse(200, request=request)
-        resp = self.arch.post(
-            "path/path",
-            request,
-            headers={"headerfield1": "headervalue1"},
-        )
-        self.assertEqual(
-            tuple(mock_post.call_args),
-            (
-                (f"url/{ROOT}/path/path",),
-                {
-                    "data": '{"field1": "value1"}',
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        "headerfield1": "headervalue1",
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, request=request)
+            resp = self.arch.post(
+                "path/path",
+                request,
+                headers={"headerfield1": "headervalue1"},
+            )
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    (f"url/{ROOT}/path/path",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            "headerfield1": "headervalue1",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="POST method called incorrectly",
-        )
+                ),
+                msg="POST method called incorrectly",
+            )
 
-    @mock.patch("requests.Session.post")
-    def test_post_file(self, mock_post):
+    def test_post_file(self):
         """
         Test default post_file method
         """
-        mock_post.return_value = MockResponse(200)
-        resp = self.arch.post_file(
-            "path/path",
-            BytesIO(b"lotsofbytes"),
-            "image/jpg",
-        )
-        args, kwargs = mock_post.call_args
-        self.assertEqual(
-            len(args),
-            1,
-            msg="Incorrect number of arguments",
-        )
-        self.assertEqual(
-            args[0],
-            f"url/{ROOT}/path/path",
-            msg="Incorrect first argument",
-        )
-        self.assertEqual(
-            len(kwargs),
-            4,
-            msg="Incorrect number of keyword arguments",
-        )
-        headers = kwargs.get("headers")
-        self.assertNotEqual(
-            headers,
-            None,
-            msg="Header does not exist",
-        )
-        self.assertTrue(
-            headers["content-type"].startswith("multipart/form-data"),
-            msg="Incorrect content-type",
-        )
-        data = kwargs.get("data")
-        self.assertIsNotNone(
-            data,
-            msg="Incorrect data",
-        )
-        fields = data.fields
-        self.assertIsNotNone(
-            fields,
-            msg="Incorrect fields",
-        )
-        myfile = fields.get("file")
-        self.assertIsNotNone(
-            myfile,
-            msg="Incorrect file key",
-        )
-        self.assertEqual(
-            myfile[0],
-            "filename",
-            msg="Incorrect filename",
-        )
-        self.assertEqual(
-            myfile[2],
-            "image/jpg",
-            msg="Incorrect mimetype",
-        )
-
-    @mock.patch("requests.Session.post")
-    def test_post_file_with_error(self, mock_post):
-        """
-        Test post method with error
-        """
-        mock_post.return_value = MockResponse(400)
-        with self.assertRaises(ArchivistBadRequestError):
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200)
             resp = self.arch.post_file(
                 "path/path",
                 BytesIO(b"lotsofbytes"),
                 "image/jpg",
             )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                len(args),
+                1,
+                msg="Incorrect number of arguments",
+            )
+            self.assertEqual(
+                args[0],
+                f"url/{ROOT}/path/path",
+                msg="Incorrect first argument",
+            )
+            self.assertEqual(
+                len(kwargs),
+                4,
+                msg="Incorrect number of keyword arguments",
+            )
+            headers = kwargs.get("headers")
+            self.assertNotEqual(
+                headers,
+                None,
+                msg="Header does not exist",
+            )
+            self.assertTrue(
+                headers["content-type"].startswith("multipart/form-data"),
+                msg="Incorrect content-type",
+            )
+            data = kwargs.get("data")
+            self.assertIsNotNone(
+                data,
+                msg="Incorrect data",
+            )
+            fields = data.fields
+            self.assertIsNotNone(
+                fields,
+                msg="Incorrect fields",
+            )
+            myfile = fields.get("file")
+            self.assertIsNotNone(
+                myfile,
+                msg="Incorrect file key",
+            )
+            self.assertEqual(
+                myfile[0],
+                "filename",
+                msg="Incorrect filename",
+            )
+            self.assertEqual(
+                myfile[2],
+                "image/jpg",
+                msg="Incorrect mimetype",
+            )
+
+    def test_post_file_with_error(self):
+        """
+        Test post method with error
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(400)
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.post_file(
+                    "path/path",
+                    BytesIO(b"lotsofbytes"),
+                    "image/jpg",
+                )
 
 
 class TestArchivistGet(TestArchivistMethods):
@@ -284,76 +285,13 @@ class TestArchivistGet(TestArchivistMethods):
     Test Archivist Get method
     """
 
-    @mock.patch("requests.Session.get")
-    def test_get(self, mock_get):
+    def test_get(self):
         """
         Test default get method
         """
-        mock_get.return_value = MockResponse(200)
-        resp = self.arch.get("path/path", "entity/xxxxxxxx")
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_ring_buffer(self, mock_get):
-        """
-        Test That the ring buffer for response objects works as expected
-        """
-        mock_get.return_value = MockResponse(200)
-        resp = self.arch.get("path/path", "entity/xxxxxxxx")
-        last_response = self.arch.last_response()
-        self.assertEqual(last_response, [mock_get.return_value])
-
-    @mock.patch("requests.Session.get")
-    def test_get_with_error(self, mock_get):
-        """
-        Test get method with error
-        """
-        mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
-        with self.assertRaises(ArchivistNotFoundError):
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200)
             resp = self.arch.get("path/path", "entity/xxxxxxxx")
-
-    @mock.patch("requests.Session.get")
-    def test_get_file(self, mock_get):
-        """
-        Test default get method
-        """
-
-        def iter_content():
-            i = 0
-
-            def filedata(chunk_size=4096):  # pylint: disable=unused-argument
-                nonlocal i
-                while i < 4:
-                    i += 1
-
-                    if i == 2:
-                        yield None
-
-                    yield b"chunkofbytes"
-
-            return filedata
-
-        mock_get.return_value = MockResponse(
-            200,
-            identity="entity/xxxxxxxx",
-            iter_content=iter_content(),
-        )
-        with BytesIO() as fd:
-            resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -365,335 +303,101 @@ class TestArchivistGet(TestArchivistMethods):
                         },
                         "verify": True,
                         "cert": None,
-                        "stream": True,
                     },
                 ),
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_get_file_with_error(self, mock_get):
+    def test_ring_buffer(self):
+        """
+        Test That the ring buffer for response objects works as expected
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200)
+            resp = self.arch.get("path/path", "entity/xxxxxxxx")
+            last_response = self.arch.last_response()
+            self.assertEqual(last_response, [mock_get.return_value])
+
+    def test_get_with_error(self):
         """
         Test get method with error
         """
-        mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
-        with self.assertRaises(ArchivistNotFoundError):
-            with BytesIO() as fd:
-                resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
+            with self.assertRaises(ArchivistNotFoundError):
+                resp = self.arch.get("path/path", "entity/xxxxxxxx")
 
-    @mock.patch("requests.Session.get")
-    def test_get_with_headers(self, mock_get):
+    def test_get_file(self):
         """
         Test default get method
         """
-        mock_get.return_value = MockResponse(200)
-        resp = self.arch.get(
-            "path/path",
-            "id/xxxxxxxx",
-            headers={"headerfield1": "headervalue1"},
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (f"url/{ROOT}/path/path/id/xxxxxxxx",),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        "headerfield1": "headervalue1",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
 
+        with mock.patch.object(self.arch._session, "get") as mock_get:
 
-class TestArchivistDelete(TestArchivistMethods):
-    """
-    Test Archivist Delete method
-    """
+            def iter_content():
+                i = 0
 
-    @mock.patch("requests.Session.delete")
-    def test_delete(self, mock_delete):
-        """
-        Test default delete method
-        """
-        mock_delete.return_value = MockResponse(200)
-        resp = self.arch.delete("path/path", "entity/xxxxxxxx")
-        self.assertEqual(
-            tuple(mock_delete.call_args),
-            (
-                (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="DELETE method called incorrectly",
-        )
+                def filedata(chunk_size=4096):  # pylint: disable=unused-argument
+                    nonlocal i
+                    while i < 4:
+                        i += 1
 
-    @mock.patch("requests.Session.delete")
-    def test_delete_with_error(self, mock_delete):
-        """
-        Test delete method with error
-        """
-        mock_delete.return_value = MockResponse(404, identity="entity/xxxxxxxx")
-        with self.assertRaises(ArchivistNotFoundError):
-            resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+                        if i == 2:
+                            yield None
 
-    @mock.patch("requests.Session.delete")
-    def test_delete_with_headers(self, mock_delete):
-        """
-        Test default delete method
-        """
-        mock_delete.return_value = MockResponse(200)
-        resp = self.arch.delete(
-            "path/path",
-            "id/xxxxxxxx",
-            headers={"headerfield1": "headervalue1"},
-        )
-        self.assertEqual(
-            tuple(mock_delete.call_args),
-            (
-                (f"url/{ROOT}/path/path/id/xxxxxxxx",),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        "headerfield1": "headervalue1",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="DELETE method called incorrectly",
-        )
+                        yield b"chunkofbytes"
 
+                return filedata
 
-class TestArchivistPatch(TestArchivistMethods):
-    """
-    Test Archivist PATCH method
-    """
-
-    @mock.patch("requests.Session.patch")
-    def test_patch(self, mock_patch):
-        """
-        Test default patch method
-        """
-        request = {"field1": "value1"}
-        mock_patch.return_value = MockResponse(200, request=request)
-        resp = self.arch.patch("path/path", "entity/xxxx", request)
-        self.assertEqual(
-            tuple(mock_patch.call_args),
-            (
-                (f"url/{ROOT}/path/path/entity/xxxx",),
-                {
-                    "data": '{"field1": "value1"}',
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="POST method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.patch")
-    def test_patch_with_error(self, mock_patch):
-        """
-        Test post method with error
-        """
-        request = {"field1": "value1"}
-        mock_patch.return_value = MockResponse(400, request=request, field1="value1")
-        with self.assertRaises(ArchivistBadRequestError):
-            resp = self.arch.patch("path/path", "entity/xxxx", request)
-
-    @mock.patch("requests.Session.patch")
-    def test_patch_with_headers(self, mock_patch):
-        """
-        Test default patch method
-        """
-        request = {"field1": "value1"}
-        mock_patch.return_value = MockResponse(200, request=request)
-        resp = self.arch.patch(
-            "path/path",
-            "entity/xxxx",
-            request,
-            headers={"headerfield1": "headervalue1"},
-        )
-        self.assertEqual(
-            tuple(mock_patch.call_args),
-            (
-                (f"url/{ROOT}/path/path/entity/xxxx",),
-                {
-                    "data": '{"field1": "value1"}',
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        "headerfield1": "headervalue1",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="PATCH method called incorrectly",
-        )
-
-
-class TestArchivistCount(TestArchivistMethods):
-    """
-    Test Archivist count method
-    """
-
-    @mock.patch("requests.Session.get")
-    def test_count(self, mock_get):
-        """
-        Test default count method
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        count = self.arch.count("path/path")
-        self.assertEqual(
-            count,
-            1,
-            msg="incorrect count",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_count_with_error(self, mock_get):
-        """
-        Test default count method with error
-        """
-        mock_get.return_value = MockResponse(
-            400,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        with self.assertRaises(ArchivistBadRequestError):
-            count = self.arch.count("path/path")
-
-
-class TestArchivistList(TestArchivistMethods):
-    """
-    Test Archivist list method
-    """
-
-    @mock.patch("requests.Session.get")
-    def test_list(self, mock_get):
-        """
-        Test default list method
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        responses = list(self.arch.list("path/path", "things"))
-        self.assertEqual(
-            len(responses),
-            1,
-            msg="incorrect number of responses",
-        )
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
-                (
-                    (f"url/{ROOT}/path/path",),
-                    {
-                        "headers": {
-                            "content-type": "application/json",
-                            "authorization": "Bearer authauthauth",
-                        },
-                        "verify": True,
-                        "cert": None,
-                    },
-                ),
-                msg="GET method called incorrectly",
+            mock_get.return_value = MockResponse(
+                200,
+                identity="entity/xxxxxxxx",
+                iter_content=iter_content(),
             )
+            with BytesIO() as fd:
+                resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+                self.assertEqual(
+                    tuple(mock_get.call_args),
+                    (
+                        (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                            "stream": True,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
 
-    @mock.patch("requests.Session.get")
-    def test_list_with_error(self, mock_get):
+    def test_get_file_with_error(self):
         """
-        Test default list method with error
+        Test get method with error
         """
-        mock_get.return_value = MockResponse(
-            400,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        with self.assertRaises(ArchivistBadRequestError):
-            responses = list(self.arch.list("path/path", "things"))
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
+            with self.assertRaises(ArchivistNotFoundError):
+                with BytesIO() as fd:
+                    resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
 
-    @mock.patch("requests.Session.get")
-    def test_list_with_bad_field(self, mock_get):
+    def test_get_with_headers(self):
         """
-        Test default list method with error
+        Test default get method
         """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        with self.assertRaises(ArchivistBadFieldError):
-            responses = list(self.arch.list("path/path", "badthings"))
-
-    @mock.patch("requests.Session.get")
-    def test_list_with_headers(self, mock_get):
-        """
-        Test default list method
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        responses = list(
-            self.arch.list(
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200)
+            resp = self.arch.get(
                 "path/path",
-                "things",
+                "id/xxxxxxxx",
                 headers={"headerfield1": "headervalue1"},
             )
-        )
-        self.assertEqual(
-            len(responses),
-            1,
-            msg="incorrect number of responses",
-        )
-        for a in mock_get.call_args_list:
             self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/path/path",),
+                    (f"url/{ROOT}/path/path/id/xxxxxxxx",),
                     {
                         "headers": {
                             "content-type": "application/json",
@@ -707,36 +411,23 @@ class TestArchivistList(TestArchivistMethods):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_list_with_query(self, mock_get):
+
+class TestArchivistDelete(TestArchivistMethods):
+    """
+    Test Archivist Delete method
+    """
+
+    def test_delete(self):
         """
-        Test default list method
+        Test default delete method
         """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        responses = list(
-            self.arch.list(
-                "path/path",
-                "things",
-                query={"queryfield1": "queryvalue1"},
-            )
-        )
-        self.assertEqual(
-            len(responses),
-            1,
-            msg="incorrect number of responses",
-        )
-        for a in mock_get.call_args_list:
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200)
+            resp = self.arch.delete("path/path", "entity/xxxxxxxx")
             self.assertEqual(
-                tuple(a),
+                tuple(mock_delete.call_args),
                 (
-                    (f"url/{ROOT}/path/path?queryfield1=queryvalue1",),
+                    (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
                     {
                         "headers": {
                             "content-type": "application/json",
@@ -746,71 +437,329 @@ class TestArchivistList(TestArchivistMethods):
                         "cert": None,
                     },
                 ),
-                msg="GET method called incorrectly",
+                msg="DELETE method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_list_with_page_size(self, mock_get):
+    def test_delete_with_error(self):
+        """
+        Test delete method with error
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(404, identity="entity/xxxxxxxx")
+            with self.assertRaises(ArchivistNotFoundError):
+                resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+
+    def test_delete_with_headers(self):
+        """
+        Test default delete method
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200)
+            resp = self.arch.delete(
+                "path/path",
+                "id/xxxxxxxx",
+                headers={"headerfield1": "headervalue1"},
+            )
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    (f"url/{ROOT}/path/path/id/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            "headerfield1": "headervalue1",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )
+
+
+class TestArchivistPatch(TestArchivistMethods):
+    """
+    Test Archivist PATCH method
+    """
+
+    def test_patch(self):
+        """
+        Test default patch method
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "patch") as mock_patch:
+            mock_patch.return_value = MockResponse(200, request=request)
+            resp = self.arch.patch("path/path", "entity/xxxx", request)
+            self.assertEqual(
+                tuple(mock_patch.call_args),
+                (
+                    (f"url/{ROOT}/path/path/entity/xxxx",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="POST method called incorrectly",
+            )
+
+    def test_patch_with_error(self):
+        """
+        Test post method with error
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "patch") as mock_patch:
+            mock_patch.return_value = MockResponse(
+                400, request=request, field1="value1"
+            )
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.patch("path/path", "entity/xxxx", request)
+
+    def test_patch_with_headers(self):
+        """
+        Test default patch method
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "patch") as mock_patch:
+            mock_patch.return_value = MockResponse(200, request=request)
+            resp = self.arch.patch(
+                "path/path",
+                "entity/xxxx",
+                request,
+                headers={"headerfield1": "headervalue1"},
+            )
+            self.assertEqual(
+                tuple(mock_patch.call_args),
+                (
+                    (f"url/{ROOT}/path/path/entity/xxxx",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            "headerfield1": "headervalue1",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="PATCH method called incorrectly",
+            )
+
+
+class TestArchivistCount(TestArchivistMethods):
+    """
+    Test Archivist count method
+    """
+
+    def test_count(self):
+        """
+        Test default count method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            count = self.arch.count("path/path")
+            self.assertEqual(
+                count,
+                1,
+                msg="incorrect count",
+            )
+
+    def test_count_with_error(self):
+        """
+        Test default count method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                400,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            with self.assertRaises(ArchivistBadRequestError):
+                count = self.arch.count("path/path")
+
+
+class TestArchivistList(TestArchivistMethods):
+    """
+    Test Archivist list method
+    """
+
+    def test_list(self):
+        """
+        Test default list method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            responses = list(self.arch.list("path/path", "things"))
+            self.assertEqual(
+                len(responses),
+                1,
+                msg="incorrect number of responses",
+            )
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/path/path",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_list_with_error(self):
+        """
+        Test default list method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                400,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            with self.assertRaises(ArchivistBadRequestError):
+                responses = list(self.arch.list("path/path", "things"))
+
+    def test_list_with_bad_field(self):
+        """
+        Test default list method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            with self.assertRaises(ArchivistBadFieldError):
+                responses = list(self.arch.list("path/path", "badthings"))
+
+    def test_list_with_headers(self):
+        """
+        Test default list method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            responses = list(
+                self.arch.list(
+                    "path/path",
+                    "things",
+                    headers={"headerfield1": "headervalue1"},
+                )
+            )
+            self.assertEqual(
+                len(responses),
+                1,
+                msg="incorrect number of responses",
+            )
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/path/path",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                                "headerfield1": "headervalue1",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_list_with_query(self):
+        """
+        Test default list method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            responses = list(
+                self.arch.list(
+                    "path/path",
+                    "things",
+                    query={"queryfield1": "queryvalue1"},
+                )
+            )
+            self.assertEqual(
+                len(responses),
+                1,
+                msg="incorrect number of responses",
+            )
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/path/path?queryfield1=queryvalue1",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_list_with_page_size(self):
         """
         Test default list method
         """
         values = ("value10", "value11")
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": values[0],
-                },
-                {
-                    "field1": values[1],
-                },
-            ],
-        )
-        responses = list(
-            self.arch.list(
-                "path/path",
-                "things",
-                page_size=2,
-            )
-        )
-        self.assertEqual(
-            len(responses),
-            2,
-            msg="incorrect number of responses",
-        )
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
-                (
-                    (f"url/{ROOT}/path/path?page_size=2",),
-                    {
-                        "headers": {
-                            "content-type": "application/json",
-                            "authorization": "Bearer authauthauth",
-                        },
-                        "verify": True,
-                        "cert": None,
-                    },
-                ),
-                msg="GET method called incorrectly",
-            )
-
-        for i, r in enumerate(responses):
-            self.assertEqual(
-                r["field1"],
-                values[i],
-                msg="Incorrect response body value",
-            )
-
-    @mock.patch("requests.Session.get")
-    def test_list_with_multiple_pages(self, mock_get):
-        """
-        Test default list method
-        """
-        values = ("value10", "value11", "value12", "value13")
-        paging = ("page_size=2", "page_token=token")
-        mock_get.side_effect = [
-            MockResponse(
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
                 200,
                 things=[
                     {
@@ -820,55 +769,110 @@ class TestArchivistList(TestArchivistMethods):
                         "field1": values[1],
                     },
                 ],
-                next_page_token="token",
-            ),
-            MockResponse(
-                200,
-                things=[
-                    {
-                        "field1": values[2],
-                    },
-                    {
-                        "field1": values[3],
-                    },
-                ],
-            ),
-        ]
-        responses = list(
-            self.arch.list(
-                "path/path",
-                "things",
-                page_size=2,
             )
-        )
-        self.assertEqual(
-            len(responses),
-            4,
-            msg="incorrect number of responses",
-        )
-        for i, a in enumerate(mock_get.call_args_list):
+            responses = list(
+                self.arch.list(
+                    "path/path",
+                    "things",
+                    page_size=2,
+                )
+            )
             self.assertEqual(
-                tuple(a),
-                (
-                    (f"url/{ROOT}/path/path?{paging[i]}",),
-                    {
-                        "headers": {
-                            "content-type": "application/json",
-                            "authorization": "Bearer authauthauth",
+                len(responses),
+                2,
+                msg="incorrect number of responses",
+            )
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/path/path?page_size=2",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
                         },
-                        "verify": True,
-                        "cert": None,
-                    },
-                ),
-                msg="GET method called incorrectly",
-            )
+                    ),
+                    msg="GET method called incorrectly",
+                )
 
-        for i, r in enumerate(responses):
-            self.assertEqual(
-                r["field1"],
-                values[i],
-                msg="Incorrect response body value",
+            for i, r in enumerate(responses):
+                self.assertEqual(
+                    r["field1"],
+                    values[i],
+                    msg="Incorrect response body value",
+                )
+
+    def test_list_with_multiple_pages(self):
+        """
+        Test default list method
+        """
+        values = ("value10", "value11", "value12", "value13")
+        paging = ("page_size=2", "page_token=token")
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = [
+                MockResponse(
+                    200,
+                    things=[
+                        {
+                            "field1": values[0],
+                        },
+                        {
+                            "field1": values[1],
+                        },
+                    ],
+                    next_page_token="token",
+                ),
+                MockResponse(
+                    200,
+                    things=[
+                        {
+                            "field1": values[2],
+                        },
+                        {
+                            "field1": values[3],
+                        },
+                    ],
+                ),
+            ]
+            responses = list(
+                self.arch.list(
+                    "path/path",
+                    "things",
+                    page_size=2,
+                )
             )
+            self.assertEqual(
+                len(responses),
+                4,
+                msg="incorrect number of responses",
+            )
+            for i, a in enumerate(mock_get.call_args_list):
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/path/path?{paging[i]}",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+            for i, r in enumerate(responses):
+                self.assertEqual(
+                    r["field1"],
+                    values[i],
+                    msg="Incorrect response body value",
+                )
 
 
 class TestArchivistSignature(TestArchivistMethods):
@@ -876,86 +880,88 @@ class TestArchivistSignature(TestArchivistMethods):
     Test Archivist get_by_signature method
     """
 
-    @mock.patch("requests.Session.get")
-    def test_get_by_signature(self, mock_get):
+    def test_get_by_signature(self):
         """
         Test default get_by_signature method
         """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        entity = self.arch.get_by_signature("path/path", "things", {"field1": "value1"})
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
-                (
-                    (f"url/{ROOT}/path/path?page_size=2&field1=value1",),
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
                     {
-                        "headers": {
-                            "content-type": "application/json",
-                            "authorization": "Bearer authauthauth",
-                        },
-                        "verify": True,
-                        "cert": None,
+                        "field1": "value1",
                     },
-                ),
-                msg="GET method called incorrectly",
+                ],
             )
-
-    @mock.patch("requests.Session.get")
-    def test_get_by_signature_not_found(self, mock_get):
-        """
-        Test default get_by_signature method
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[],
-        )
-        with self.assertRaises(ArchivistNotFoundError):
             entity = self.arch.get_by_signature(
                 "path/path", "things", {"field1": "value1"}
             )
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/path/path?page_size=2&field1=value1",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
 
-    @mock.patch("requests.Session.get")
-    def test_get_by_signature_duplicate(self, mock_get):
+    def test_get_by_signature_not_found(self):
         """
         Test default get_by_signature method
         """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        with self.assertRaises(ArchivistDuplicateError):
-            entity = self.arch.get_by_signature(
-                "path/path", "things", {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[],
             )
+            with self.assertRaises(ArchivistNotFoundError):
+                entity = self.arch.get_by_signature(
+                    "path/path", "things", {"field1": "value1"}
+                )
 
-    @mock.patch("requests.Session.get")
-    def test_get_by_signature_with_bad_field(self, mock_get):
+    def test_get_by_signature_duplicate(self):
+        """
+        Test default get_by_signature method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            with self.assertRaises(ArchivistDuplicateError):
+                entity = self.arch.get_by_signature(
+                    "path/path", "things", {"field1": "value1"}
+                )
+
+    def test_get_by_signature_with_bad_field(self):
         """
         Test default list method with error
         """
-        mock_get.return_value = MockResponse(
-            200,
-            things=[
-                {
-                    "field1": "value1",
-                },
-            ],
-        )
-        with self.assertRaises(ArchivistBadFieldError):
-            entity = self.arch.get_by_signature(
-                "path/path", "badthings", {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
             )
+            with self.assertRaises(ArchivistBadFieldError):
+                entity = self.arch.get_by_signature(
+                    "path/path", "badthings", {"field1": "value1"}
+                )

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -22,6 +22,7 @@ from archivist.storage_integrity import StorageIntegrity
 from .mock_response import MockResponse
 
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 # pylint: disable=unused-variable
 
 
@@ -131,315 +132,213 @@ class TestAssets(TestCase):
     def tearDown(self):
         confirm.MAX_TIME = self.confirm_MAX_TIME
 
-    @mock.patch("requests.Session.post")
-    def test_assets_create(self, mock_post):
+    def test_assets_create(self):
         """
         Test asset creation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
 
-        asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=False)
-        self.assertEqual(
-            tuple(mock_post.call_args),
-            (
-                ((f"url/{ROOT}/{ASSETS_SUBPATH}" f"/{ASSETS_LABEL}"),),
-                {
-                    "data": REQUEST_DATA,
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
+            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=False)
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    ((f"url/{ROOT}/{ASSETS_SUBPATH}" f"/{ASSETS_LABEL}"),),
+                    {
+                        "data": REQUEST_DATA,
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="CREATE method called incorrectly",
-        )
-        self.assertEqual(
-            asset,
-            RESPONSE,
-            msg="CREATE method called incorrectly",
-        )
-        self.assertEqual(
-            asset.primary_image,
-            PRIMARY_IMAGE,
-            msg="Incorrect primary image",
-        )
-        self.assertEqual(
-            asset.name,
-            ASSET_NAME,
-            msg="Incorrect name property",
-        )
+                ),
+                msg="CREATE method called incorrectly",
+            )
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+            self.assertEqual(
+                asset.primary_image,
+                PRIMARY_IMAGE,
+                msg="Incorrect primary image",
+            )
+            self.assertEqual(
+                asset.name,
+                ASSET_NAME,
+                msg="Incorrect name property",
+            )
 
-    @mock.patch("requests.Session.get")
-    @mock.patch("requests.Session.post")
-    def test_assets_create_with_confirmation(self, mock_post, mock_get):
+    def test_assets_create_with_confirmation(self):
         """
         Test asset creation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
-        mock_get.return_value = MockResponse(200, **RESPONSE)
-        asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
-        self.assertEqual(
-            asset,
-            RESPONSE,
-            msg="CREATE method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    @mock.patch("requests.Session.post")
-    def test_assets_create_with_confirmation_no_confirmed_status(
-        self,
-        mock_post,
-        mock_get,
-    ):
-        """
-        Test asset confirmation
-        """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
-        mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
-
-        with self.assertRaises(ArchivistUnconfirmedError):
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
             asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
 
-    @mock.patch("requests.Session.get")
-    @mock.patch("requests.Session.post")
-    def test_assets_create_with_confirmation_pending_status(
-        self,
-        mock_post,
-        mock_get,
-    ):
+    def test_assets_create_with_confirmation_no_confirmed_status(self):
         """
         Test asset confirmation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
-        mock_get.side_effect = [
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE),
-        ]
-        asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
-        self.assertEqual(
-            asset,
-            RESPONSE,
-            msg="CREATE method called incorrectly",
-        )
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
 
-    @mock.patch("requests.Session.get")
-    @mock.patch("requests.Session.post")
-    def test_assets_create_with_confirmation_failed_status(
-        self,
-        mock_post,
-        mock_get,
-    ):
+            with self.assertRaises(ArchivistUnconfirmedError):
+                asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+
+    def test_assets_create_with_confirmation_pending_status(self):
         """
         Test asset confirmation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
-        mock_get.side_effect = [
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_FAILED),
-        ]
-        with self.assertRaises(ArchivistUnconfirmedError):
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE),
+            ]
             asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
 
-    @mock.patch("requests.Session.get")
-    @mock.patch("requests.Session.post")
-    def test_assets_create_with_confirmation_always_pending_status(
-        self,
-        mock_post,
-        mock_get,
-    ):
+    def test_assets_create_with_confirmation_failed_status(self):
         """
         Test asset confirmation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
-        mock_get.side_effect = [
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_PENDING),
-            MockResponse(200, **RESPONSE_PENDING),
-        ]
-        with self.assertRaises(ArchivistUnconfirmedError):
-            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_FAILED),
+            ]
+            with self.assertRaises(ArchivistUnconfirmedError):
+                asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
 
-    @mock.patch("requests.Session.get")
-    def test_assets_read_with_out_primary_image(self, mock_get):
+    def test_assets_create_with_confirmation_always_pending_status(self):
+        """
+        Test asset confirmation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE_PENDING),
+            ]
+            with self.assertRaises(ArchivistUnconfirmedError):
+                asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+
+    def test_assets_read_with_out_primary_image(self):
         """
         Test asset reading
         """
-        mock_get.return_value = MockResponse(200, **RESPONSE_NO_ATTACHMENTS)
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200, **RESPONSE_NO_ATTACHMENTS)
 
-        asset = self.arch.assets.read(IDENTITY)
-        self.assertEqual(
-            asset,
-            RESPONSE_NO_ATTACHMENTS,
-            msg="READ method called incorrectly",
-        )
-        self.assertIsNone(
-            asset.primary_image,
-            msg="There should be no primary image",
-        )
-        self.assertIsNone(
-            asset.name,
-            msg="There should be no name property",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_assets_count(self, mock_get):
-        """
-        Test asset counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            assets=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.assets.count()
-        self.assertEqual(
-            count,
-            1,
-            msg="Incorrect count",
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_assets_count_with_props_query(self, mock_get):
-        """
-        Test asset counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            assets=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.assets.count(
-            props={
-                "confirmation_status": "CONFIRMED",
-            },
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (
-                    (
-                        f"url/{ROOT}/{SUBPATH}"
-                        "?page_size=1"
-                        "&confirmation_status=CONFIRMED"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_assets_count_with_attrs_query(self, mock_get):
-        """
-        Test asset counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            assets=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.assets.count(
-            attrs={"arc_firmware_version": "1.0"},
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (
-                    (
-                        f"url/{ROOT}/{SUBPATH}"
-                        "?page_size=1"
-                        "&attributes.arc_firmware_version=1.0"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_assets_wait_for_confirmed(self, mock_get):
-        """
-        Test asset counting
-        """
-        ## last call to get looks for FAILED assets
-        status = ("PENDING", "PENDING", "FAILED")
-        mock_get.side_effect = [
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 0},
-                assets=[],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 0},
-                assets=[],
-            ),
-        ]
-
-        self.arch.assets.wait_for_confirmed()
-        for i, a in enumerate(mock_get.call_args_list):
+            asset = self.arch.assets.read(IDENTITY)
             self.assertEqual(
-                tuple(a),
+                asset,
+                RESPONSE_NO_ATTACHMENTS,
+                msg="READ method called incorrectly",
+            )
+            self.assertIsNone(
+                asset.primary_image,
+                msg="There should be no primary image",
+            )
+            self.assertIsNone(
+                asset.name,
+                msg="There should be no name property",
+            )
+
+    def test_assets_count(self):
+        """
+        Test asset counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                assets=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.assets.count()
+            self.assertEqual(
+                count,
+                1,
+                msg="Incorrect count",
+            )
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+
+    def test_assets_count_with_props_query(self):
+        """
+        Test asset counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                assets=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.assets.count(
+                props={
+                    "confirmation_status": "CONFIRMED",
+                },
+            )
+            self.assertEqual(
+                tuple(mock_get.call_args),
                 (
                     (
                         (
                             f"url/{ROOT}/{SUBPATH}"
                             "?page_size=1"
-                            f"&confirmation_status={status[i]}"
+                            "&confirmation_status=CONFIRMED"
                         ),
                     ),
                     {
@@ -455,181 +354,37 @@ class TestAssets(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_assets_wait_for_confirmed_timeout(self, mock_get):
+    def test_assets_count_with_attrs_query(self):
         """
         Test asset counting
         """
-        ## last call to get looks for FAILED assets
-        mock_get.side_effect = [
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-        ]
-
-        with self.assertRaises(ArchivistUnconfirmedError):
-            self.arch.assets.wait_for_confirmed()
-
-    @mock.patch("requests.Session.get")
-    def test_assets_wait_for_confirmed_failed(self, mock_get):
-        """
-        Test asset counting
-        """
-        ## last call to get looks for FAILED assets
-        mock_get.side_effect = [
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 2},
-                assets=[
-                    RESPONSE_PENDING,
-                ],
-            ),
-            MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 0},
-                assets=[],
-            ),
-            MockResponse(
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
                 200,
                 headers={HEADERS_TOTAL_COUNT: 1},
                 assets=[
-                    RESPONSE_FAILED,
+                    RESPONSE,
                 ],
-            ),
-        ]
-
-        with self.assertRaises(ArchivistUnconfirmedError):
-            self.arch.assets.wait_for_confirmed()
-
-    @mock.patch("requests.Session.get")
-    def test_assets_list(self, mock_get):
-        """
-        Test asset listing
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            assets=[
-                RESPONSE,
-            ],
-        )
-
-        assets = list(self.arch.assets.list())
-        self.assertEqual(
-            len(assets),
-            1,
-            msg="incorrect number of assets",
-        )
-        for asset in assets:
-            self.assertEqual(
-                asset,
-                RESPONSE,
-                msg="Incorrect asset listed",
             )
 
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
-                (
-                    (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
-                    {
-                        "headers": {
-                            "content-type": "application/json",
-                            "authorization": "Bearer authauthauth",
-                        },
-                        "verify": True,
-                        "cert": None,
-                    },
-                ),
-                msg="GET method called incorrectly",
-            )
-
-    @mock.patch("requests.Session.get")
-    def test_assets_list_with_query(self, mock_get):
-        """
-        Test asset listing
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            assets=[
-                RESPONSE,
-            ],
-        )
-
-        assets = list(
-            self.arch.assets.list(
-                props={
-                    "confirmation_status": "CONFIRMED",
-                },
+            count = self.arch.assets.count(
                 attrs={"arc_firmware_version": "1.0"},
             )
-        )
-        self.assertEqual(
-            len(assets),
-            1,
-            msg="incorrect number of assets",
-        )
-        for asset in assets:
             self.assertEqual(
-                asset,
-                RESPONSE,
-                msg="Incorrect asset listed",
-            )
-
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
                     (
                         (
                             f"url/{ROOT}/{SUBPATH}"
-                            f"?page_size={DEFAULT_PAGE_SIZE}"
+                            "?page_size=1"
                             "&attributes.arc_firmware_version=1.0"
-                            "&confirmation_status=CONFIRMED"
                         ),
                     ),
                     {
                         "headers": {
                             "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
                         "verify": True,
                         "cert": None,
@@ -638,37 +393,272 @@ class TestAssets(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_assets_read_by_signature(self, mock_get):
+    def test_assets_wait_for_confirmed(self):
+        """
+        Test asset counting
+        """
+        ## last call to get looks for FAILED assets
+        status = ("PENDING", "PENDING", "FAILED")
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = [
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
+                ),
+            ]
+
+            self.arch.assets.wait_for_confirmed()
+            for i, a in enumerate(mock_get.call_args_list):
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            (
+                                f"url/{ROOT}/{SUBPATH}"
+                                "?page_size=1"
+                                f"&confirmation_status={status[i]}"
+                            ),
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                                HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_assets_wait_for_confirmed_timeout(self):
+        """
+        Test asset counting
+        """
+        ## last call to get looks for FAILED assets
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = [
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+            ]
+
+            with self.assertRaises(ArchivistUnconfirmedError):
+                self.arch.assets.wait_for_confirmed()
+
+    def test_assets_wait_for_confirmed_failed(self):
+        """
+        Test asset counting
+        """
+        ## last call to get looks for FAILED assets
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = [
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 1},
+                    assets=[
+                        RESPONSE_FAILED,
+                    ],
+                ),
+            ]
+
+            with self.assertRaises(ArchivistUnconfirmedError):
+                self.arch.assets.wait_for_confirmed()
+
+    def test_assets_list(self):
         """
         Test asset listing
         """
-        mock_get.return_value = MockResponse(
-            200,
-            assets=[
-                RESPONSE,
-            ],
-        )
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                assets=[
+                    RESPONSE,
+                ],
+            )
 
-        asset = self.arch.assets.read_by_signature()
-        self.assertEqual(
-            asset,
-            RESPONSE,
-            msg="Incorrect asset listed",
-        )
+            assets = list(self.arch.assets.list())
+            self.assertEqual(
+                len(assets),
+                1,
+                msg="incorrect number of assets",
+            )
+            for asset in assets:
+                self.assertEqual(
+                    asset,
+                    RESPONSE,
+                    msg="Incorrect asset listed",
+                )
 
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (f"url/{ROOT}/{SUBPATH}?page_size=2",),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_assets_list_with_query(self):
+        """
+        Test asset listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                assets=[
+                    RESPONSE,
+                ],
+            )
+
+            assets = list(
+                self.arch.assets.list(
+                    props={
+                        "confirmation_status": "CONFIRMED",
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
+                    attrs={"arc_firmware_version": "1.0"},
+                )
+            )
+            self.assertEqual(
+                len(assets),
+                1,
+                msg="incorrect number of assets",
+            )
+            for asset in assets:
+                self.assertEqual(
+                    asset,
+                    RESPONSE,
+                    msg="Incorrect asset listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            (
+                                f"url/{ROOT}/{SUBPATH}"
+                                f"?page_size={DEFAULT_PAGE_SIZE}"
+                                "&attributes.arc_firmware_version=1.0"
+                                "&confirmation_status=CONFIRMED"
+                            ),
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_assets_read_by_signature(self):
+        """
+        Test asset listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                assets=[
+                    RESPONSE,
+                ],
+            )
+
+            asset = self.arch.assets.read_by_signature()
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="Incorrect asset listed",
+            )
+
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    (f"url/{ROOT}/{SUBPATH}?page_size=2",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )

--- a/unittests/testattachments.py
+++ b/unittests/testattachments.py
@@ -11,6 +11,8 @@ from archivist.constants import ROOT, ATTACHMENTS_SUBPATH, ATTACHMENTS_LABEL
 
 from .mock_response import MockResponse
 
+# pylint: disable=protected-access
+
 
 PROPS = {
     "hash": {"alg": "SHA256", "value": "xxxxxxxxxxxxxxxxxxxxxxx"},
@@ -39,120 +41,121 @@ class TestAttachments(TestCase):
         self.arch = Archivist("url", auth="authauthauth")
         self.mockstream = BytesIO(b"somelongstring")
 
-    @mock.patch("requests.Session.post")
-    def test_attachments_upload(self, mock_post):
+    def test_attachments_upload(self):
         """
         Test attachment upload
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
 
-        attachment = self.arch.attachments.upload(self.mockstream)
-        args, kwargs = mock_post.call_args
-        self.assertEqual(
-            args,
-            (f"url/{ROOT}/{SUBPATH}",),
-            msg="UPLOAD method called incorrectly",
-        )
-        self.assertTrue(
-            "headers" in kwargs,
-            msg="UPLOAD no headers found",
-        )
-        headers = kwargs["headers"]
-        self.assertTrue(
-            "authorization" in headers,
-            msg="UPLOAD no authorization found",
-        )
-        self.assertEqual(
-            headers["authorization"],
-            "Bearer authauthauth",
-            msg="UPLOAD incorrect authorization",
-        )
-        self.assertTrue(
-            headers["content-type"].startswith("multipart/form-data;"),
-            msg="UPLOAD incorrect content-type",
-        )
-        self.assertTrue(
-            kwargs["verify"],
-            msg="UPLOAD method called incorrectly",
-        )
-        self.assertIsNone(
-            kwargs["cert"],
-            msg="UPLOAD method called incorrectly",
-        )
-        self.assertTrue(
-            "data" in kwargs,
-            msg="UPLOAD no data found",
-        )
-        fields = kwargs["data"].fields
-        self.assertTrue(
-            "file" in fields,
-            msg="UPLOAD no file found",
-        )
-        self.assertEqual(
-            fields["file"][0],
-            "filename",
-            msg="UPLOAD incorrect filename",
-        )
-        self.assertEqual(
-            fields["file"][2],
-            "image/jpg",
-            msg="UPLOAD incorrect filetype",
-        )
-        self.assertEqual(
-            attachment,
-            RESPONSE,
-            msg="UPLOAD method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_attachments_download(self, mock_get):
-        """
-        Test attachment download
-        """
-
-        def iter_content():
-            i = 0
-
-            def filedata(chunk_size=4096):  # pylint: disable=unused-argument
-                nonlocal i
-                while i < 4:
-                    i += 1
-
-                    if i == 2:
-                        yield None
-
-                    yield b"chunkofbytes"
-
-            return filedata
-
-        mock_get.return_value = MockResponse(
-            200,
-            iter_content=iter_content(),
-            **RESPONSE,
-        )
-        with BytesIO() as fd:
-            attachment = self.arch.attachments.download(IDENTITY, fd)
-            args, kwargs = mock_get.call_args
+            attachment = self.arch.attachments.upload(self.mockstream)
+            args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,
-                (f"url/{ROOT}/{ATTACHMENTS_SUBPATH}/{IDENTITY}",),
-                msg="DOWNLOAD method called incorrectly",
+                (f"url/{ROOT}/{SUBPATH}",),
+                msg="UPLOAD method called incorrectly",
+            )
+            self.assertTrue(
+                "headers" in kwargs,
+                msg="UPLOAD no headers found",
+            )
+            headers = kwargs["headers"]
+            self.assertTrue(
+                "authorization" in headers,
+                msg="UPLOAD no authorization found",
             )
             self.assertEqual(
-                kwargs,
-                {
-                    "cert": None,
-                    "headers": {
-                        "authorization": "Bearer authauthauth",
-                        "content-type": "application/json",
-                    },
-                    "stream": True,
-                    "verify": True,
-                },
-                msg="DOWNLOAD method called incorrectly",
+                headers["authorization"],
+                "Bearer authauthauth",
+                msg="UPLOAD incorrect authorization",
+            )
+            self.assertTrue(
+                headers["content-type"].startswith("multipart/form-data;"),
+                msg="UPLOAD incorrect content-type",
+            )
+            self.assertTrue(
+                kwargs["verify"],
+                msg="UPLOAD method called incorrectly",
+            )
+            self.assertIsNone(
+                kwargs["cert"],
+                msg="UPLOAD method called incorrectly",
+            )
+            self.assertTrue(
+                "data" in kwargs,
+                msg="UPLOAD no data found",
+            )
+            fields = kwargs["data"].fields
+            self.assertTrue(
+                "file" in fields,
+                msg="UPLOAD no file found",
+            )
+            self.assertEqual(
+                fields["file"][0],
+                "filename",
+                msg="UPLOAD incorrect filename",
+            )
+            self.assertEqual(
+                fields["file"][2],
+                "image/jpg",
+                msg="UPLOAD incorrect filetype",
             )
             self.assertEqual(
                 attachment,
                 RESPONSE,
-                msg="DOWNLOAD method called incorrectly",
+                msg="UPLOAD method called incorrectly",
             )
+
+    def test_attachments_download(self):
+        """
+        Test attachment download
+        """
+
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+
+            def iter_content():
+                i = 0
+
+                def filedata(chunk_size=4096):  # pylint: disable=unused-argument
+                    nonlocal i
+                    while i < 4:
+                        i += 1
+
+                        if i == 2:
+                            yield None
+
+                        yield b"chunkofbytes"
+
+                return filedata
+
+            mock_get.return_value = MockResponse(
+                200,
+                iter_content=iter_content(),
+                **RESPONSE,
+            )
+            with BytesIO() as fd:
+                attachment = self.arch.attachments.download(IDENTITY, fd)
+                args, kwargs = mock_get.call_args
+                self.assertEqual(
+                    args,
+                    (f"url/{ROOT}/{ATTACHMENTS_SUBPATH}/{IDENTITY}",),
+                    msg="DOWNLOAD method called incorrectly",
+                )
+                self.assertEqual(
+                    kwargs,
+                    {
+                        "cert": None,
+                        "headers": {
+                            "authorization": "Bearer authauthauth",
+                            "content-type": "application/json",
+                        },
+                        "stream": True,
+                        "verify": True,
+                    },
+                    msg="DOWNLOAD method called incorrectly",
+                )
+                self.assertEqual(
+                    attachment,
+                    RESPONSE,
+                    msg="DOWNLOAD method called incorrectly",
+                )

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -20,6 +20,7 @@ from .mock_response import MockResponse
 
 
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 # pylint: disable=unused-variable
 
 PROPS = {
@@ -61,213 +62,48 @@ class TestLocations(TestCase):
     def setUp(self):
         self.arch = Archivist("url", auth="authauthauth")
 
-    @mock.patch("requests.Session.post")
-    def test_locations_create(self, mock_post):
+    def test_locations_create(self):
         """
         Test location creation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
 
-        location = self.arch.locations.create(PROPS, attrs=ATTRS)
-        self.assertEqual(
-            tuple(mock_post.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}"),),
-                {
-                    "data": REQUEST_DATA,
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="CREATE method called incorrectly",
-        )
-        self.assertEqual(
-            location,
-            RESPONSE,
-            msg="CREATE method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_locations_read(self, mock_get):
-        """
-        Test asset reading
-        """
-        mock_get.return_value = MockResponse(200, **RESPONSE)
-
-        asset = self.arch.locations.read(IDENTITY)
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{LOCATIONS_SUBPATH}/{IDENTITY}"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_locations_read_with_error(self, mock_get):
-        """
-        Test read method with error
-        """
-        mock_get.return_value = MockResponse(400)
-        with self.assertRaises(ArchivistBadRequestError):
-            resp = self.arch.locations.read(IDENTITY)
-
-    @mock.patch("requests.Session.get")
-    def test_locations_count(self, mock_get):
-        """
-        Test location counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            locations=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.locations.count()
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-        self.assertEqual(
-            count,
-            1,
-            msg="Incorrect count",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_locations_count_with_props_query(self, mock_get):
-        """
-        Test location counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            locations=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.locations.count(
-            props={"display_name": "Macclesfield, Cheshire"},
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
+            location = self.arch.locations.create(PROPS, attrs=ATTRS)
+            self.assertEqual(
+                tuple(mock_post.call_args),
                 (
-                    (
-                        f"url/{ROOT}/{SUBPATH}"
-                        "?page_size=1"
-                        "&display_name=Macclesfield, Cheshire"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
+                    ((f"url/{ROOT}/{SUBPATH}"),),
+                    {
+                        "data": REQUEST_DATA,
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_locations_count_with_attrs_query(self, mock_get):
-        """
-        Test location counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            locations=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.locations.count(
-            attrs={"director": "John Smith"},
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (
-                    (
-                        f"url/{ROOT}/{SUBPATH}"
-                        "?page_size=1"
-                        "&attributes.director=John Smith"
-                    ),
                 ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_locations_list(self, mock_get):
-        """
-        Test location listing
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            locations=[
-                RESPONSE,
-            ],
-        )
-
-        locations = list(self.arch.locations.list())
-        self.assertEqual(
-            len(locations),
-            1,
-            msg="incorrect number of locations",
-        )
-        for location in locations:
+                msg="CREATE method called incorrectly",
+            )
             self.assertEqual(
                 location,
                 RESPONSE,
-                msg="Incorrect location listed",
+                msg="CREATE method called incorrectly",
             )
 
-        for a in mock_get.call_args_list:
+    def test_locations_read(self):
+        """
+        Test asset reading
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+
+            asset = self.arch.locations.read(IDENTITY)
             self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                    ((f"url/{ROOT}/{LOCATIONS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
                             "content-type": "application/json",
@@ -280,45 +116,74 @@ class TestLocations(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_locations_list_with_query(self, mock_get):
+    def test_locations_read_with_error(self):
         """
-        Test location listing
+        Test read method with error
         """
-        mock_get.return_value = MockResponse(
-            200,
-            locations=[
-                RESPONSE,
-            ],
-        )
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(400)
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.locations.read(IDENTITY)
 
-        locations = list(
-            self.arch.locations.list(
+    def test_locations_count(self):
+        """
+        Test location counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                locations=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.locations.count()
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+            self.assertEqual(
+                count,
+                1,
+                msg="Incorrect count",
+            )
+
+    def test_locations_count_with_props_query(self):
+        """
+        Test location counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                locations=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.locations.count(
                 props={"display_name": "Macclesfield, Cheshire"},
-                attrs={"director": "John Smith"},
             )
-        )
-        self.assertEqual(
-            len(locations),
-            1,
-            msg="incorrect number of locations",
-        )
-        for location in locations:
             self.assertEqual(
-                location,
-                RESPONSE,
-                msg="Incorrect location listed",
-            )
-
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
                     (
                         (
                             f"url/{ROOT}/{SUBPATH}"
-                            f"?page_size={DEFAULT_PAGE_SIZE}"
-                            "&attributes.director=John Smith"
+                            "?page_size=1"
                             "&display_name=Macclesfield, Cheshire"
                         ),
                     ),
@@ -326,6 +191,7 @@ class TestLocations(TestCase):
                         "headers": {
                             "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
                         "verify": True,
                         "cert": None,
@@ -334,37 +200,172 @@ class TestLocations(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_locations_read_by_signature(self, mock_get):
+    def test_locations_count_with_attrs_query(self):
+        """
+        Test location counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                locations=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.locations.count(
+                attrs={"director": "John Smith"},
+            )
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    (
+                        (
+                            f"url/{ROOT}/{SUBPATH}"
+                            "?page_size=1"
+                            "&attributes.director=John Smith"
+                        ),
+                    ),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+
+    def test_locations_list(self):
+        """
+        Test location listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                locations=[
+                    RESPONSE,
+                ],
+            )
+
+            locations = list(self.arch.locations.list())
+            self.assertEqual(
+                len(locations),
+                1,
+                msg="incorrect number of locations",
+            )
+            for location in locations:
+                self.assertEqual(
+                    location,
+                    RESPONSE,
+                    msg="Incorrect location listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_locations_list_with_query(self):
+        """
+        Test location listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                locations=[
+                    RESPONSE,
+                ],
+            )
+
+            locations = list(
+                self.arch.locations.list(
+                    props={"display_name": "Macclesfield, Cheshire"},
+                    attrs={"director": "John Smith"},
+                )
+            )
+            self.assertEqual(
+                len(locations),
+                1,
+                msg="incorrect number of locations",
+            )
+            for location in locations:
+                self.assertEqual(
+                    location,
+                    RESPONSE,
+                    msg="Incorrect location listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            (
+                                f"url/{ROOT}/{SUBPATH}"
+                                f"?page_size={DEFAULT_PAGE_SIZE}"
+                                "&attributes.director=John Smith"
+                                "&display_name=Macclesfield, Cheshire"
+                            ),
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_locations_read_by_signature(self):
         """
         Test location read_by_signature
         """
-        mock_get.return_value = MockResponse(
-            200,
-            locations=[
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                locations=[
+                    RESPONSE,
+                ],
+            )
+
+            location = self.arch.locations.read_by_signature()
+            self.assertEqual(
+                location,
                 RESPONSE,
-            ],
-        )
+                msg="Incorrect location listed",
+            )
 
-        location = self.arch.locations.read_by_signature()
-        self.assertEqual(
-            location,
-            RESPONSE,
-            msg="Incorrect location listed",
-        )
-
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                (f"url/{ROOT}/{SUBPATH}?page_size=2",),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    (f"url/{ROOT}/{SUBPATH}?page_size=2",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
+                ),
+                msg="GET method called incorrectly",
+            )

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -20,6 +20,7 @@ from .mock_response import MockResponse
 
 
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 # pylint: disable=unused-variable
 
 DISPLAY_NAME = "Subject display name"
@@ -64,228 +65,50 @@ class TestSubjects(TestCase):
     def setUp(self):
         self.arch = Archivist("url", auth="authauthauth")
 
-    @mock.patch("requests.Session.post")
-    def test_subjects_create(self, mock_post):
+    def test_subjects_create(self):
         """
         Test subject creation
         """
-        mock_post.return_value = MockResponse(200, **RESPONSE)
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
 
-        subject = self.arch.subjects.create(
-            DISPLAY_NAME, WALLET_PUB_KEYS, TESSERA_PUB_KEYS
-        )
-        self.assertEqual(
-            tuple(mock_post.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}"),),
-                {
-                    "data": REQUEST_DATA,
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="CREATE method called incorrectly",
-        )
-        self.assertEqual(
-            subject,
-            RESPONSE,
-            msg="CREATE method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_subjects_read(self, mock_get):
-        """
-        Test subject reading
-        """
-        mock_get.return_value = MockResponse(200, **RESPONSE)
-
-        subject = self.arch.subjects.read(IDENTITY)
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.delete")
-    def test_subjects_delete(self, mock_delete):
-        """
-        Test subject deleting
-        """
-        mock_delete.return_value = MockResponse(200, {})
-
-        subject = self.arch.subjects.delete(IDENTITY)
-        self.assertEqual(
-            tuple(mock_delete.call_args),
-            (
-                ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="DELETE method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.patch")
-    def test_subjects_update(self, mock_patch):
-        """
-        Test subject deleting
-        """
-        mock_patch.return_value = MockResponse(200, **RESPONSE)
-
-        subject = self.arch.subjects.update(
-            IDENTITY,
-            display_name=DISPLAY_NAME,
-        )
-        self.assertEqual(
-            tuple(mock_patch.call_args),
-            (
-                ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
-                {
-                    "data": UPDATE_DATA,
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="PATCH method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_subjects_read_with_error(self, mock_get):
-        """
-        Test read method with error
-        """
-        mock_get.return_value = MockResponse(400)
-        with self.assertRaises(ArchivistBadRequestError):
-            resp = self.arch.subjects.read(IDENTITY)
-
-    @mock.patch("requests.Session.get")
-    def test_subjects_count(self, mock_get):
-        """
-        Test subject counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            subjects=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.subjects.count()
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
-                ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
-                    },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-        self.assertEqual(
-            count,
-            1,
-            msg="Incorrect count",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_subjects_count_by_name(self, mock_get):
-        """
-        Test subject counting
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            headers={HEADERS_TOTAL_COUNT: 1},
-            subjects=[
-                RESPONSE,
-            ],
-        )
-
-        count = self.arch.subjects.count(
-            display_name="Subject display name",
-        )
-        self.assertEqual(
-            tuple(mock_get.call_args),
-            (
+            subject = self.arch.subjects.create(
+                DISPLAY_NAME, WALLET_PUB_KEYS, TESSERA_PUB_KEYS
+            )
+            self.assertEqual(
+                tuple(mock_post.call_args),
                 (
-                    (
-                        f"url/{ROOT}/{SUBPATH}"
-                        "?page_size=1"
-                        "&display_name=Subject display name"
-                    ),
-                ),
-                {
-                    "headers": {
-                        "content-type": "application/json",
-                        "authorization": "Bearer authauthauth",
-                        HEADERS_REQUEST_TOTAL_COUNT: "true",
+                    ((f"url/{ROOT}/{SUBPATH}"),),
+                    {
+                        "data": REQUEST_DATA,
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
                     },
-                    "verify": True,
-                    "cert": None,
-                },
-            ),
-            msg="GET method called incorrectly",
-        )
-
-    @mock.patch("requests.Session.get")
-    def test_subjects_list(self, mock_get):
-        """
-        Test subject listing
-        """
-        mock_get.return_value = MockResponse(
-            200,
-            subjects=[
-                RESPONSE,
-            ],
-        )
-
-        subjects = list(self.arch.subjects.list())
-        self.assertEqual(
-            len(subjects),
-            1,
-            msg="incorrect number of subjects",
-        )
-        for subject in subjects:
+                ),
+                msg="CREATE method called incorrectly",
+            )
             self.assertEqual(
                 subject,
                 RESPONSE,
-                msg="Incorrect subject listed",
+                msg="CREATE method called incorrectly",
             )
 
-        for a in mock_get.call_args_list:
+    def test_subjects_read(self):
+        """
+        Test subject reading
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+
+            subject = self.arch.subjects.read(IDENTITY)
             self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                    ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
                             "content-type": "application/json",
@@ -298,43 +121,126 @@ class TestSubjects(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    @mock.patch("requests.Session.get")
-    def test_subjects_list_by_name(self, mock_get):
+    def test_subjects_delete(self):
         """
-        Test subject listing
+        Test subject deleting
         """
-        mock_get.return_value = MockResponse(
-            200,
-            subjects=[
-                RESPONSE,
-            ],
-        )
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200, {})
 
-        subjects = list(
-            self.arch.subjects.list(
+            subject = self.arch.subjects.delete(IDENTITY)
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )
+
+    def test_subjects_update(self):
+        """
+        Test subject deleting
+        """
+        with mock.patch.object(self.arch._session, "patch") as mock_patch:
+            mock_patch.return_value = MockResponse(200, **RESPONSE)
+
+            subject = self.arch.subjects.update(
+                IDENTITY,
+                display_name=DISPLAY_NAME,
+            )
+            self.assertEqual(
+                tuple(mock_patch.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
+                    {
+                        "data": UPDATE_DATA,
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="PATCH method called incorrectly",
+            )
+
+    def test_subjects_read_with_error(self):
+        """
+        Test read method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(400)
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.subjects.read(IDENTITY)
+
+    def test_subjects_count(self):
+        """
+        Test subject counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                subjects=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.subjects.count()
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+            self.assertEqual(
+                count,
+                1,
+                msg="Incorrect count",
+            )
+
+    def test_subjects_count_by_name(self):
+        """
+        Test subject counting
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                headers={HEADERS_TOTAL_COUNT: 1},
+                subjects=[
+                    RESPONSE,
+                ],
+            )
+
+            count = self.arch.subjects.count(
                 display_name="Subject display name",
             )
-        )
-        self.assertEqual(
-            len(subjects),
-            1,
-            msg="incorrect number of subjects",
-        )
-        for subject in subjects:
             self.assertEqual(
-                subject,
-                RESPONSE,
-                msg="Incorrect subject listed",
-            )
-
-        for a in mock_get.call_args_list:
-            self.assertEqual(
-                tuple(a),
+                tuple(mock_get.call_args),
                 (
                     (
                         (
                             f"url/{ROOT}/{SUBPATH}"
-                            f"?page_size={DEFAULT_PAGE_SIZE}"
+                            "?page_size=1"
                             "&display_name=Subject display name"
                         ),
                     ),
@@ -342,6 +248,7 @@ class TestSubjects(TestCase):
                         "headers": {
                             "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
                         "verify": True,
                         "cert": None,
@@ -349,3 +256,97 @@ class TestSubjects(TestCase):
                 ),
                 msg="GET method called incorrectly",
             )
+
+    def test_subjects_list(self):
+        """
+        Test subject listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                subjects=[
+                    RESPONSE,
+                ],
+            )
+
+            subjects = list(self.arch.subjects.list())
+            self.assertEqual(
+                len(subjects),
+                1,
+                msg="incorrect number of subjects",
+            )
+            for subject in subjects:
+                self.assertEqual(
+                    subject,
+                    RESPONSE,
+                    msg="Incorrect subject listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_subjects_list_by_name(self):
+        """
+        Test subject listing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                subjects=[
+                    RESPONSE,
+                ],
+            )
+
+            subjects = list(
+                self.arch.subjects.list(
+                    display_name="Subject display name",
+                )
+            )
+            self.assertEqual(
+                len(subjects),
+                1,
+                msg="incorrect number of subjects",
+            )
+            for subject in subjects:
+                self.assertEqual(
+                    subject,
+                    RESPONSE,
+                    msg="Incorrect subject listed",
+                )
+
+            for a in mock_get.call_args_list:
+                self.assertEqual(
+                    tuple(a),
+                    (
+                        (
+                            (
+                                f"url/{ROOT}/{SUBPATH}"
+                                f"?page_size={DEFAULT_PAGE_SIZE}"
+                                "&display_name=Subject display name"
+                            ),
+                        ),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )


### PR DESCRIPTION
Problem:
The unittests mocked session methods where they are defined instead of
where they are used.

Solution:
Use mock.patch.object() to mock self.arch._session

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>