### PR TITLE
Make wait for confirmation more ergonomic

### DIFF
--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -166,6 +166,20 @@ class _AssetsClient:
 
         return wait_for_confirmation(self, asset["identity"])  # type: ignore
 
+    def wait_for_confirmation(self, identity: str) -> bool:
+        """Wait for asset to be confirmed.
+
+        Waits asset to be confirmed.
+
+        Args:
+            identity (str): identity of asset
+
+        Returns:
+            True if asset is confirmed.
+
+        """
+        return wait_for_confirmation(self, identity)
+
     def read(self, identity: str) -> Asset:
         """Read asset
 

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -174,6 +174,20 @@ class _EventsClient:
 
         return wait_for_confirmation(self, event["identity"])  # type: ignore
 
+    def wait_for_confirmation(self, identity: str) -> bool:
+        """Wait for event to be confirmed.
+
+        Waits for event to be confirmed.
+
+        Args:
+            identity (str): identity of event
+
+        Returns:
+            True if event is confirmed.
+
+        """
+        return wait_for_confirmation(self, identity)
+
     def read(self, identity: str) -> Event:
         """Read event
 

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -67,6 +67,17 @@ def create_asset(arch):
     return arch.assets.create(
         behaviours, attrs, storage_integrity=storage_integrity, confirm=True
     )
+    # alternatively if some work can be done whilst the asset is confirmed then this call can be
+    # replaced by a two-step alternative:
+
+    # asset = arch.assets.create(
+    #    behaviours, attrs, storage_integrity=storage_integrity, confirm=False
+    # )
+
+    # ... do something else here
+    # and then wait for confirmation
+
+    # self.arch.assets.wait_for_confirmation(asset['identity']))
 
 
 def main():

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -51,7 +51,16 @@ def create_event(arch, asset):
         "conformance_report": "blobs/e2a1d16c-03cd-45a1-8cd0-690831df1273",
     }
 
-    return arch.events.create(asset["identity"], props=props, attrs=attrs)
+    return arch.events.create(asset["identity"], props=props, attrs=attrs, confirm=True)
+    # alternatively if some work can be done whilst the event is confirmed then this call can be
+    # replaced by a two-step alternative:
+
+    # event = arch.events.create(asset["identity"], props=props, attrs=attrs, confirm=False)
+
+    # ... do something else here
+    # and then wait for confirmation
+
+    # self.arch.events.wait_for_confirmation(event['identity'])
 
 
 def create_asset(arch):

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -188,6 +188,23 @@ class TestAssets(TestCase):
                 msg="CREATE method called incorrectly",
             )
 
+    def test_assets_create_with_explicit_confirmation(self):
+        """
+        Test asset creation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=False)
+            self.arch.assets.wait_for_confirmation(asset["identity"])
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
     def test_assets_create_with_confirmation_no_confirmed_status(self):
         """
         Test asset confirmation

--- a/unittests/testevents.py
+++ b/unittests/testevents.py
@@ -25,6 +25,7 @@ from .mock_response import MockResponse
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
+# pylint: disable=too-many-public-methods
 
 ASSET_ID = f"{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
 
@@ -327,6 +328,25 @@ class TestEvents(TestCase):
             mock_get.return_value = MockResponse(200, **RESPONSE)
 
             event = self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
+            self.assertEqual(
+                event,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_events_create_with_explicit_confirmation(self):
+        """
+        Test event creation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+
+            event = self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=False)
+            self.arch.events.wait_for_confirmation(event["identity"])
             self.assertEqual(
                 event,
                 RESPONSE,


### PR DESCRIPTION
Problem:
The uage of wait_for_confirmation requires an extra import
and a clumsy invocation.

Solution:
Added wait_for_confimation as method in the assets and evenst classes.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>