### PR TITLE
Assets create should use Properties

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Run integrity checks
       run: |
         ./scripts/version.sh
-        pycodestyle --format=pylint archivist unittests examples
-        python3 -m pylint --rcfile=pylintrc archivist unittests examples
-        black archivist examples unittests
+        pycodestyle --format=pylint archivist unittests examples functests
+        python3 -m pylint --rcfile=pylintrc archivist unittests examples functests
+        black archivist examples unittests functests
         modified=$(git status -s | wc -l)
         if [ $modified -gt 0 ]
         then

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -128,7 +128,7 @@ class _AssetsClient:
         Creates asset with defined properties and attributes.
 
         Args:
-            props (list): Properties - usually only the storage_integrity setting
+            props (dict): Properties - usually only the storage_integrity setting
             attrs (dict): attributes of created asset.
             confirm (bool): if True wait for asset to be confirmed.
 

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -36,43 +36,27 @@ def create_asset(arch):
         "some_custom_attribute": "value"  # You can add any custom value as long as
         # it does not start with arc_
     }
-    behaviours = [
-        "Attachments",
-        "RecordEvidence",
-    ]
     #
     # store asset on the DLT or not. If DLT is not enabled for the user an error will occur if
     # StorageIntegrity.LEDGER is specified. If unspecified then TENANT_STORAGE is used
     # i.e. not stored on the DLT...
     # storage_integrity = StorageIntegrity.TENANT_STORAGE
-    storage_integrity = StorageIntegrity.LEDGER
+    props = {
+        "storage_integrity": StorageIntegrity.LEDGER,
+    }
 
-    # The first argument is the behaviours of the asset
-    # The second argument is the attributes of the asset
-    # The third argument indicates whether the asset is stored on the DLT or not.
-    #   If not specifed the asset is not stored on the DLT (TENANT_STORAGE)
-    # The fourth argument is wait for confirmation:
+    # The first argument are the properties of the asset
+    # The second argument are the attributes of the asset
+    # The third argument is wait for confirmation:
     #   If @confirm@ is True then this function will not
     #   return until the asset is confirmed on the blockchain and ready
     #   to accept events (or an error occurs)
     #
-    # If storage_integrity = StorageIntegrity.LEDGER:
-    #   After an asset is submitted to the blockchain,
-    #   it will be in the "Pending" status.
-    #   Once it is added to the blockchain, the status will be changed to "Confirmed"
-    #
-    # If storage_integrity = StorageIntegrity.TENANT_STORAGE:
-    #   The asset is simply stored in the backend (and not on the blockchain)
-    #   and, once stored, the status will be changed to "Confirmed".
-    return arch.assets.create(
-        behaviours, attrs, storage_integrity=storage_integrity, confirm=True
-    )
+    return arch.assets.create(props, attrs, confirm=True)
     # alternatively if some work can be done whilst the asset is confirmed then this call can be
     # replaced by a two-step alternative:
 
-    # asset = arch.assets.create(
-    #    behaviours, attrs, storage_integrity=storage_integrity, confirm=False
-    # )
+    # asset = arch.assets.create(props, attrs, confirm=False)
 
     # ... do something else here
     # and then wait for confirmation

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -89,12 +89,8 @@ def create_asset(arch):
         "some_custom_attribute": "value"  # You can add any custom value as long as
         # it does not start with arc_
     }
-    behaviours = [
-        "Attachments",
-        "RecordEvidence",
-    ]
-
-    # The first argument is the behaviours of the asset
+    props = {}
+    # The first argument is the properties of the asset
     # The second argument is the attributes of the asset
     # The third argument is wait for confirmation:
     #   If @confirm@ is True then this function will not
@@ -103,7 +99,7 @@ def create_asset(arch):
     #   After an asset is submitted to the blockchain (submitted),
     #   it will be in the "Pending" status.
     #   Once it is added to the blockchain, the status will be changed to "Confirmed"
-    return arch.assets.create(behaviours, attrs, confirm=True)
+    return arch.assets.create(props, attrs, confirm=True)
 
 
 def main():

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -13,10 +13,7 @@ from archivist.storage_integrity import StorageIntegrity
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
-BEHAVIOURS = [
-    "RecordEvidence",
-    "Attachments",
-]
+PROPS = {}
 ATTRS = {
     "arc_firmware_version": "1.0",
     "arc_serial_number": "vtl-x4-07",
@@ -46,7 +43,7 @@ class TestAssetCreate(TestCase):
         Test asset creation on tenant storage
         """
         asset = self.arch.assets.create(
-            BEHAVIOURS,
+            PROPS,
             self.attrs,
             confirm=True,
         )
@@ -61,9 +58,10 @@ class TestAssetCreate(TestCase):
         Test asset creation on ledger
         """
         asset = self.arch.assets.create(
-            BEHAVIOURS,
+            {
+                "storage_integrity": StorageIntegrity.LEDGER,
+            },
             self.attrs,
-            storage_integrity=StorageIntegrity.LEDGER,
             confirm=True,
         )
         self.assertEqual(

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -7,7 +7,7 @@ import json
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
-from archivist.assets import DEFAULT_PAGE_SIZE
+from archivist.assets import BEHAVIOURS, DEFAULT_PAGE_SIZE
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
@@ -25,10 +25,6 @@ from .mock_response import MockResponse
 # pylint: disable=unused-variable
 
 
-BEHAVIOURS = [
-    "RecordEvidence",
-    "Attachments",
-]
 PRIMARY_IMAGE = {
     "arc_display_name": "arc_primary_image",
     "arc_attachment_identity": "blobs/87b1a84c-1c6f-442b-923e-a97516f4d275",
@@ -76,11 +72,13 @@ ATTRS_NO_ATTACHMENTS = {
 IDENTITY = f"{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 SUBPATH = f"{ASSETS_SUBPATH}/{ASSETS_LABEL}"
 
-# TBD: add properties as well
+PROPS = {
+    "storage_integrity": StorageIntegrity.TENANT_STORAGE.name,
+}
 REQUEST = {
-    "behaviours": BEHAVIOURS,
     "storage_integrity": StorageIntegrity.TENANT_STORAGE.name,
     "attributes": ATTRS,
+    "behaviours": BEHAVIOURS,
 }
 REQUEST_DATA = json.dumps(REQUEST)
 
@@ -136,7 +134,7 @@ class TestAssets(TestCase):
         with mock.patch.object(self.arch._session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=False)
+            asset = self.arch.assets.create(PROPS, ATTRS, confirm=False)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (
@@ -178,7 +176,7 @@ class TestAssets(TestCase):
         ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
             mock_post.return_value = MockResponse(200, **RESPONSE)
             mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+            asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
             self.assertEqual(
                 asset,
                 RESPONSE,
@@ -194,7 +192,7 @@ class TestAssets(TestCase):
         ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
             mock_post.return_value = MockResponse(200, **RESPONSE)
             mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=False)
+            asset = self.arch.assets.create(PROPS, ATTRS, confirm=False)
             self.arch.assets.wait_for_confirmation(asset["identity"])
             self.assertEqual(
                 asset,
@@ -213,7 +211,7 @@ class TestAssets(TestCase):
             mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
 
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+                asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_pending_status(self):
         """
@@ -227,7 +225,7 @@ class TestAssets(TestCase):
                 MockResponse(200, **RESPONSE_PENDING),
                 MockResponse(200, **RESPONSE),
             ]
-            asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+            asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
             self.assertEqual(
                 asset,
                 RESPONSE,
@@ -247,7 +245,7 @@ class TestAssets(TestCase):
                 MockResponse(200, **RESPONSE_FAILED),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+                asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_always_pending_status(self):
         """
@@ -267,7 +265,7 @@ class TestAssets(TestCase):
                 MockResponse(200, **RESPONSE_PENDING),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(BEHAVIOURS, ATTRS, confirm=True)
+                asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
 
     def test_assets_read_with_out_primary_image(self):
         """


### PR DESCRIPTION
Problem:
Assets create method allows user to chosse behaviours. This
feature is deprecated in favour of using a properties argumant.

Solution:
Remove the use of behaviours in the arg list and replace with a
properties argument. Currently only the storage integrity setting
is allowed in the properties argument. storage integrity is removed from
the arguments to assets.create. This will be consistent with other
methods across the different endpoints of the API.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>