### PR TITLE
Predefined settings for any endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ One can then use the examples code to create assets (see examples directory):
     
     from archivist.archivist import Archivist
     from archivist.errors import ArchivistError
+    from archivist.storage_integrity import StorageIntegrity
     
     # Oauth2 token that grants access
     with open(".auth_token", mode='r') as tokenfile:
@@ -54,9 +55,16 @@ One can then use the examples code to create assets (see examples directory):
             "some_custom_attribute": "value"  # You can add any custom value as long as
                                           # it does not start with arc_
     }
-    behaviours = ["Attachments", "RecordEvidence"]
-    
-    # The first argument is the behaviours of the asset
+    #
+    # store asset on the DLT or not. If DLT is not enabled for the user an error will occur if
+    # StorageIntegrity.LEDGER is specified. If unspecified then TENANT_STORAGE is used
+    # i.e. not stored on the DLT...
+    # storage_integrity = StorageIntegrity.TENANT_STORAGE
+    props = {
+        "storage_integrity": StorageIntegrity.LEDGER.name,
+    }
+
+    # The first argument is the properties of the asset
     # The second argument is the attributes of the asset
     # The third argument is wait for confirmation:
     #   If @confirm@ is True then this function will not
@@ -66,7 +74,7 @@ One can then use the examples code to create assets (see examples directory):
     #   it will be in the "Pending" status.
     #   Once it is added to the blockchain, the status will be changed to "Confirmed"
     try:
-        asset = arch.assets.create(behaviours, attrs=attrs, confirm=True)
+        asset = arch.assets.create(props=props, attrs=attrs, confirm=True)
     except Archivisterror as ex:
         print("error", ex)
     else:

--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -35,6 +35,7 @@ from .constants import (
     ACCESS_POLICIES_LABEL,
     ASSETS_LABEL,
 )
+from .dictmerge import _deepmerge
 
 from .assets import Asset
 
@@ -42,6 +43,9 @@ from .assets import Asset
 #: :func:`~_AccessPoliciesClient.list` method. This can be overridden but should rarely
 #: be changed.
 DEFAULT_PAGE_SIZE = 500
+
+FIXTURE_LABEL = "access_policies"
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -169,8 +173,8 @@ class _AccessPoliciesClient:
         """
         return self._archivist.delete(ACCESS_POLICIES_SUBPATH, identity)
 
-    @staticmethod
     def __query(
+        self,
         props: Optional[Dict],
         *,
         filters: Optional[List] = None,
@@ -183,7 +187,7 @@ class _AccessPoliciesClient:
         if access_permissions is not None:
             query["access_permissions"] = access_permissions
 
-        return query
+        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
 
     def count(self, *, display_name: Optional[str] = None) -> int:
         """Count access policies.

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -38,6 +38,7 @@ from .constants import (
     CONFIRMATION_STATUS,
 )
 from . import confirmer
+from .dictmerge import _deepmerge
 from .errors import ArchivistNotFoundError
 
 #: Default page size - number of entities fetched in one REST GET in the
@@ -102,6 +103,9 @@ class Asset(dict):
         return None
 
 
+FIXTURE_LABEL = "assets"
+
+
 class _AssetsClient:
     """AssetsClient
 
@@ -118,9 +122,9 @@ class _AssetsClient:
 
     def create(
         self,
-        props: Dict,
-        attrs: Dict,
         *,
+        props: Optional[Dict] = None,
+        attrs: Optional[Dict] = None,
         confirm: bool = False,
     ) -> Asset:
         """Create asset
@@ -196,13 +200,12 @@ class _AssetsClient:
         """
         return Asset(**self._archivist.get(ASSETS_SUBPATH, identity))
 
-    @staticmethod
-    def __query(props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
+    def __query(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
         query = deepcopy(props) if props else {}
         if attrs:
             query["attributes"] = attrs
 
-        return query
+        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
 
     def count(
         self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None

--- a/archivist/dictmerge.py
+++ b/archivist/dictmerge.py
@@ -1,0 +1,22 @@
+"""Archivist dict deep merge
+"""
+
+from copy import deepcopy
+
+from flatten_dict import flatten, unflatten
+
+
+def _deepmerge(dct1: dict, dct2: dict) -> dict:
+    """Deep merge 2 dictionaries
+
+    The settings from dct2 overwrite or add to dct1
+    """
+    if dct1 is None:
+        return deepcopy(dct2)
+
+    return unflatten({**flatten(dct1), **flatten(dct2)})
+
+
+def _dotstring(dct: dict) -> str:
+    """Emit nested dictionary as dot delimited string"""
+    return flatten(dct, reducer="dot").items()

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -38,6 +38,7 @@ from .constants import (
     EVENTS_LABEL,
 )
 from . import confirmer
+from .dictmerge import _deepmerge
 from .errors import ArchivistNotFoundError
 
 
@@ -45,6 +46,8 @@ from .errors import ArchivistNotFoundError
 #: :func:`~_EventsClient.list` method. This can be overridden but should rarely
 #: be changed.
 DEFAULT_PAGE_SIZE = 500
+
+FIXTURE_LABEL = "events"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -211,9 +214,8 @@ class _EventsClient:
             )
         )
 
-    @staticmethod
     def __query(
-        props: Optional[Dict], attrs: Optional[Dict], asset_attrs: Optional[Dict]
+        self, props: Optional[Dict], attrs: Optional[Dict], asset_attrs: Optional[Dict]
     ) -> Dict:
         query = deepcopy(props) if props else {}
         if attrs:
@@ -221,7 +223,7 @@ class _EventsClient:
         if asset_attrs:
             query["asset_attributes"] = asset_attrs
 
-        return query
+        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
 
     def count(
         self,

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -30,12 +30,16 @@ from typing import Dict, Optional
 from archivist import archivist as type_helper
 
 from .constants import LOCATIONS_SUBPATH, LOCATIONS_LABEL
+from .dictmerge import _deepmerge
 
 
 #: Default page size - number of entities fetched in one REST GET in the
 #: :func:`~_LocationsClient.list` method. This can be overridden but should rarely
 #: be changed.
 DEFAULT_PAGE_SIZE = 500
+
+FIXTURE_LABEL = "locations"
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -117,13 +121,12 @@ class _LocationsClient:
             )
         )
 
-    @staticmethod
-    def __query(props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
+    def __query(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
         query = props or {}
         if attrs:
             query["attributes"] = attrs
 
-        return query
+        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
 
     def count(
         self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -32,11 +32,15 @@ from .constants import (
     SUBJECTS_SUBPATH,
     SUBJECTS_LABEL,
 )
+from .dictmerge import _deepmerge
 
 #: Default page size - number of entities fetched in one REST GET in the
 #: :func:`~_SubjectsClient.list` method. This can be overridden but should rarely
 #: be changed.
 DEFAULT_PAGE_SIZE = 500
+
+FIXTURE_LABEL = "subjects"
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -171,8 +175,8 @@ class _SubjectsClient:
         """
         return self._archivist.delete(SUBJECTS_SUBPATH, identity)
 
-    @staticmethod
     def __query(
+        self,
         *,
         display_name: Optional[str] = None,
         wallet_pub_keys: Optional[List[str]] = None,
@@ -190,7 +194,7 @@ class _SubjectsClient:
         if tessera_pub_keys is not None:
             query["tessera_pub_key"] = tessera_pub_keys
 
-        return query
+        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
 
     def count(self, *, display_name: Optional[str] = None) -> int:
         """Count subjects.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -25,6 +25,7 @@ REST api (in any language):
        certain criteria to become confirmed.
     *  a **read_by_signature()** method that allows one to retrieve an asset or event with a 
        unique signature without knowing the identity.
+    *  predefined **fixtures** that allow specifying common attributes of assets/events
     *  comprehensive exception handling - clear specific exceptions.
     *  easily extensible - obeys the open-closed principle of SOLID where new endpoints 
        can be implemented by **extending** the package as opposed to modifying it.

--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -1,0 +1,66 @@
+.. _fixtures:
+
+Fixtures
+=============================================
+
+One can specify common attributes when creating/counting/querying assets, events
+and locations.
+
+.. code-block:: python
+    
+    from copy import deepcopy
+
+    from archivist.archivist import Archivist
+    from archivist.errors import ArchivistError
+    from archivist.storage_integrity import StorageIntegrity
+    
+    # Oauth2 token that grants access
+    with open(".auth_token", mode='r') as tokenfile:
+        authtoken = tokenfile.read().strip()
+    
+    # Initialize connection to Archivist - for assets on DLT.
+    ledger = Archivist(
+        "https://app.rkvst.io",
+        auth=authtoken,
+        fixtures = {
+            "assets": {
+                "storage_integrity": StorageIntegrity.LEDGER.name,
+            }
+        },
+    )
+    
+    # lets define doors in our namespace that reside on the ledger...
+    doors = deepcopy(ledger)
+    doors.fixtures = {
+        "assets": {
+            "attributes": {
+                "arc_display_type": "door",
+                "arc_namespace": "project xyz",
+            },
+        },
+    }
+
+    # a red front door
+    door = doors.assets.create(
+        attrs={
+            "arc_display_name": "front door",
+            "colour": "red",
+        },
+        confirm=True,
+    )
+
+    # a green back door
+    door = doors.assets.create(
+        attrs={
+            "arc_display_name": "back door",
+            "colour": "green",
+        },
+        confirm=True,
+    )
+
+    # no need to specify arc_display_type...
+    no_of_doors = doors.assets.count()
+    for d in doors.assets.list():
+        print(d)
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Jitsuin Archivist
 
    features
    getting_started
+   fixtures
    archivist
    assets
    events

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -40,9 +40,9 @@ def create_asset(arch):
     # store asset on the DLT or not. If DLT is not enabled for the user an error will occur if
     # StorageIntegrity.LEDGER is specified. If unspecified then TENANT_STORAGE is used
     # i.e. not stored on the DLT...
-    # storage_integrity = StorageIntegrity.TENANT_STORAGE
+    # storage_integrity = StorageIntegrity.TENANT_STORAGE.name
     props = {
-        "storage_integrity": StorageIntegrity.LEDGER,
+        "storage_integrity": StorageIntegrity.LEDGER.name,
     }
 
     # The first argument are the properties of the asset
@@ -52,11 +52,11 @@ def create_asset(arch):
     #   return until the asset is confirmed on the blockchain and ready
     #   to accept events (or an error occurs)
     #
-    return arch.assets.create(props, attrs, confirm=True)
+    return arch.assets.create(props=props, attrs=attrs, confirm=True)
     # alternatively if some work can be done whilst the asset is confirmed then this call can be
     # replaced by a two-step alternative:
 
-    # asset = arch.assets.create(props, attrs, confirm=False)
+    # asset = arch.assets.create(props=props, attrs=attrs, confirm=False)
 
     # ... do something else here
     # and then wait for confirmation

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -87,17 +87,15 @@ def create_asset(arch):
         "some_custom_attribute": "value"  # You can add any custom value as long as
         # it does not start with arc_
     }
-    props = {}
-    # The first argument is the properties of the asset
-    # The second argument is the attributes of the asset
-    # The third argument is wait for confirmation:
+    # The first argument is the attributes of the asset
+    # The second argument is wait for confirmation:
     #   If @confirm@ is True then this function will not
     #   return until the asset is confirmed on the blockchain and ready
     #   to accept events (or an error occurs)
     #   After an asset is submitted to the blockchain (submitted),
     #   it will be in the "Pending" status.
     #   Once it is added to the blockchain, the status will be changed to "Confirmed"
-    return arch.assets.create(props, attrs, confirm=True)
+    return arch.assets.create(attrs=attrs, confirm=True)
 
 
 def main():

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -5,6 +5,7 @@ Test assets creation
 from copy import deepcopy
 from os import environ
 from unittest import TestCase
+from uuid import uuid4
 
 from archivist.archivist import Archivist
 from archivist.storage_integrity import StorageIntegrity
@@ -13,13 +14,10 @@ from archivist.storage_integrity import StorageIntegrity
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
-PROPS = {}
 ATTRS = {
     "arc_firmware_version": "1.0",
     "arc_serial_number": "vtl-x4-07",
     "arc_description": "Traffic flow control light at A603 North East",
-    "arc_home_location_identity": "locations/115340cf-f39e-4d43-a2ee-8017d672c6c6",
-    "arc_display_type": "Traffic light with violation camera",
     "some_custom_attribute": "value",
 }
 
@@ -32,19 +30,26 @@ class TestAssetCreate(TestCase):
     maxDiff = None
 
     @classmethod
-    def setUp(cls):
+    def setUpClass(cls):
         with open(environ["TEST_AUTHTOKEN_FILENAME"]) as fd:
             auth = fd.read().strip()
         cls.arch = Archivist(environ["TEST_ARCHIVIST"], auth=auth, verify=False)
         cls.attrs = deepcopy(ATTRS)
+        cls.traffic_light = deepcopy(ATTRS)
+        cls.traffic_light["arc_display_type"] = "Traffic light with violation camera"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.arch = None
+        cls.attrs = None
+        cls.traffic_light = None
 
     def test_asset_create_tenant_storage(self):
         """
         Test asset creation on tenant storage
         """
         asset = self.arch.assets.create(
-            PROPS,
-            self.attrs,
+            attrs=self.traffic_light,
             confirm=True,
         )
         self.assertEqual(
@@ -58,14 +63,46 @@ class TestAssetCreate(TestCase):
         Test asset creation on ledger
         """
         asset = self.arch.assets.create(
-            {
-                "storage_integrity": StorageIntegrity.LEDGER,
+            props={
+                "storage_integrity": StorageIntegrity.LEDGER.name,
             },
-            self.attrs,
+            attrs=self.traffic_light,
             confirm=True,
         )
         self.assertEqual(
             asset["storage_integrity"],
             StorageIntegrity.LEDGER.name,
             msg="Incorrect asset storage integrity",
+        )
+
+    def test_asset_create_with_fixtures(self):
+        """
+        Test creation with fixtures
+        """
+        # creates tenant_storage endpoint
+        tenant_storage = deepcopy(self.arch)
+        tenant_storage.fixtures = {
+            "assets": {
+                "storage_integrity": StorageIntegrity.TENANT_STORAGE.name,
+            },
+        }
+
+        # create traffic lights endpoint from tenant_storage
+        traffic_lights = deepcopy(tenant_storage)
+        traffic_lights.fixtures = {
+            "assets": {
+                "attributes": {
+                    "arc_display_type": "Traffic light with violation camera",
+                    "arc_namespace": f"functests {uuid4()}",
+                },
+            },
+        }
+        traffic_light = traffic_lights.assets.create(
+            attrs=self.attrs,
+            confirm=True,
+        )
+        self.assertEqual(
+            traffic_lights.assets.count(),
+            1,
+            msg="Incorrect number of traffic_lights",
         )

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -134,7 +134,7 @@ class TestAssets(TestCase):
         with mock.patch.object(self.arch._session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            asset = self.arch.assets.create(PROPS, ATTRS, confirm=False)
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (
@@ -176,7 +176,7 @@ class TestAssets(TestCase):
         ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
             mock_post.return_value = MockResponse(200, **RESPONSE)
             mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
             self.assertEqual(
                 asset,
                 RESPONSE,
@@ -192,7 +192,7 @@ class TestAssets(TestCase):
         ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
             mock_post.return_value = MockResponse(200, **RESPONSE)
             mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(PROPS, ATTRS, confirm=False)
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
             self.arch.assets.wait_for_confirmation(asset["identity"])
             self.assertEqual(
                 asset,
@@ -211,7 +211,7 @@ class TestAssets(TestCase):
             mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
 
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
+                asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_pending_status(self):
         """
@@ -225,7 +225,7 @@ class TestAssets(TestCase):
                 MockResponse(200, **RESPONSE_PENDING),
                 MockResponse(200, **RESPONSE),
             ]
-            asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
             self.assertEqual(
                 asset,
                 RESPONSE,
@@ -245,7 +245,7 @@ class TestAssets(TestCase):
                 MockResponse(200, **RESPONSE_FAILED),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
+                asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_always_pending_status(self):
         """
@@ -265,7 +265,7 @@ class TestAssets(TestCase):
                 MockResponse(200, **RESPONSE_PENDING),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(PROPS, ATTRS, confirm=True)
+                asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
 
     def test_assets_read_with_out_primary_image(self):
         """

--- a/unittests/testfixtures.py
+++ b/unittests/testfixtures.py
@@ -1,0 +1,98 @@
+"""
+Test archivist fixtures
+"""
+
+from copy import deepcopy
+
+from unittest import TestCase
+
+from archivist.archivist import Archivist
+
+
+# pylint: disable=missing-docstring
+
+
+FIXTURE1 = {
+    "assets": {
+        "attributes": {
+            "arc_display_type": "door",
+            "arc_namespace": "testfixtures",
+            "size": "large",
+            "data": [
+                "data0",
+                "data1",
+            ],
+        },
+    },
+}
+FIXTURE2 = {
+    "assets": {
+        "attributes": {
+            "arc_display_type": "card",
+            "arc_namespace": "testfixtures",
+            "colour": "blue",
+            "data": [
+                "data0",
+                "data2",
+                "data3",
+            ],
+        },
+    },
+}
+FIXTURE3 = {
+    "assets": {
+        "attributes": {
+            "arc_display_type": "card",
+            "arc_namespace": "testfixtures",
+            "colour": "blue",
+            "size": "large",
+            "data": [
+                "data0",
+                "data2",
+                "data3",
+            ],
+        },
+    },
+}
+
+
+class TestFixtures(TestCase):
+    """
+    Test Archivist class fixtures
+    """
+
+    maxDiff = None
+
+    def test_fixtures(self):
+        """
+        Test default archivist creation
+        """
+        arch = Archivist("url", auth="authauthauth")
+        self.assertEqual(
+            arch.fixtures,
+            {},
+            msg="Incorrect fixtures",
+        )
+        arch.fixtures = FIXTURE1
+        self.assertEqual(
+            arch.fixtures,
+            FIXTURE1,
+            msg="Incorrect fixtures",
+        )
+
+        # prove that deepcopy recreates all underlying fixtures
+        newarch = deepcopy(arch)
+
+        newarch.fixtures = FIXTURE2
+        self.assertEqual(
+            newarch.fixtures,
+            FIXTURE3,
+            msg="Incorrect fixtures",
+        )
+
+        # but original arch is untouched
+        self.assertEqual(
+            arch.fixtures,
+            FIXTURE1,
+            msg="Incorrect fixtures",
+        )


### PR DESCRIPTION
Problem:
Creating assets usually requires some common settings and
it is tedious to repeatedly specify them when manipulating
entities.

Solution:
Add a fixtures property that allows the user to 'accumulate'
predefined fixed settings.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>