### PR TITLE
Deepcopy Archivist fails after use

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -36,6 +36,7 @@ import json
 from os.path import isfile as os_path_isfile
 from typing import BinaryIO, Dict, List, Optional
 from collections import deque
+from copy import deepcopy
 from requests.models import Response
 
 import requests
@@ -113,7 +114,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         self._headers = {"content-type": "application/json"}
         if auth is not None:
             self._headers["authorization"] = "Bearer " + auth.strip()
-
+        self._auth = auth
         self._url = url
         self._verify = verify
         if not cert and not auth:
@@ -187,6 +188,16 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
     def fixtures(self, fixtures: dict):
         """dict: Contains predefined attributes for each endpoint"""
         self._fixtures = _deepmerge(self._fixtures, fixtures)
+
+    def __copy__(self):
+        return Archivist(
+            self._url,
+            auth=self._auth,
+            cert=self._cert,
+            fixtures=deepcopy(self._fixtures),
+            verify=self._verify,
+            max_time=self._max_time,
+        )
 
     def __add_headers(self, headers: Optional[Dict]) -> Dict:
         if headers is not None:

--- a/archivist/dictmerge.py
+++ b/archivist/dictmerge.py
@@ -12,7 +12,12 @@ def _deepmerge(dct1: dict, dct2: dict) -> dict:
     The settings from dct2 overwrite or add to dct1
     """
     if dct1 is None:
+        if dct2 is None:
+            return {}
         return deepcopy(dct2)
+
+    if dct2 is None:
+        return deepcopy(dct1)
 
     return unflatten({**flatten(dct1), **flatten(dct2)})
 

--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -8,7 +8,7 @@ and locations.
 
 .. code-block:: python
     
-    from copy import deepcopy
+    from copy import copy
 
     from archivist.archivist import Archivist
     from archivist.errors import ArchivistError
@@ -30,7 +30,7 @@ and locations.
     )
     
     # lets define doors in our namespace that reside on the ledger...
-    doors = deepcopy(ledger)
+    doors = copy(ledger)
     doors.fixtures = {
         "assets": {
             "attributes": {

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -2,6 +2,7 @@
 Test archivist
 """
 
+from copy import copy
 from io import BytesIO
 from unittest import TestCase, mock
 
@@ -76,6 +77,33 @@ class TestArchivist(TestCase):
         )
         with self.assertRaises(AttributeError):
             e = arch.Illegal_endpoint
+
+    def test_archivist_copy(self):
+        """
+        Test archivist copy
+        """
+        arch = Archivist("url", auth="authauthauth", verify=False)
+        arch1 = copy(arch)
+        self.assertEqual(
+            arch.url,
+            arch1.url,
+            msg="Incorrect url",
+        )
+        self.assertEqual(
+            arch.headers,
+            arch1.headers,
+            msg="Incorrect auth headers",
+        )
+        self.assertEqual(
+            arch.verify,
+            arch1.verify,
+            msg="Incorrect verify",
+        )
+        self.assertEqual(
+            arch.fixtures,
+            arch1.fixtures,
+            msg="Incorrect fixtures",
+        )
 
     def test_archivist_no_verify(self):
         """

--- a/unittests/testdictmerge.py
+++ b/unittests/testdictmerge.py
@@ -1,0 +1,45 @@
+"""
+Test archivist
+"""
+
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+# pylint: disable=too-few-public-methods
+
+from unittest import TestCase
+
+from archivist import dictmerge
+
+
+class TestDictMerge(TestCase):
+    """
+    Test dictmerge
+    """
+
+    def test_dictmerge(self):
+        """
+        Test dictmerge
+        """
+        self.assertEqual(
+            dictmerge._deepmerge(None, None),
+            {},
+            msg="Dictmerge returns incorrect result",
+        )
+        self.assertEqual(
+            dictmerge._deepmerge({"key": "value"}, None),
+            {"key": "value"},
+            msg="Dictmerge returns incorrect result",
+        )
+        self.assertEqual(
+            dictmerge._deepmerge(None, {"key": "value"}),
+            {"key": "value"},
+            msg="Dictmerge returns incorrect result",
+        )
+        self.assertEqual(
+            dictmerge._deepmerge(
+                {"key": "value"},
+                {"key1": "value1"},
+            ),
+            {"key": "value", "key1": "value1"},
+            msg="Dictmerge returns incorrect result",
+        )

--- a/unittests/testfixtures.py
+++ b/unittests/testfixtures.py
@@ -2,7 +2,7 @@
 Test archivist fixtures
 """
 
-from copy import deepcopy
+from copy import copy
 
 from unittest import TestCase
 
@@ -80,8 +80,8 @@ class TestFixtures(TestCase):
             msg="Incorrect fixtures",
         )
 
-        # prove that deepcopy recreates all underlying fixtures
-        newarch = deepcopy(arch)
+        # prove that copy recreates all underlying fixtures
+        newarch = copy(arch)
 
         newarch.fixtures = FIXTURE2
         self.assertEqual(


### PR DESCRIPTION
Problem:
Using an Archivist instance before copying causes an error
when a deepcopy is attempted.

Solution:
Added __copy__() method to Archivist class

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>