### PR TITLE
Handle 402 response code sensibly

### DIFF
--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -39,6 +39,10 @@ class ArchivistForbiddenError(ArchivistError):
     """User does not have permission (403)"""
 
 
+class ArchivistPaymentRequiredError(ArchivistError):
+    """A quota has been reached (402)"""
+
+
 class ArchivistNotFoundError(ArchivistError):
     """Entity does not exist (404)"""
 
@@ -101,6 +105,7 @@ def _parse_response(response):
         return {
             400: ArchivistBadRequestError(f"{text} ({status_code})"),
             401: ArchivistUnauthenticatedError(f"{text} ({status_code})"),
+            402: ArchivistPaymentRequiredError(f"{text} ({status_code})"),
             403: ArchivistForbiddenError(f"{text} ({status_code})"),
             404: ArchivistNotFoundError(
                 f"{__identity(response)} not found ({status_code})"

--- a/unittests/testerrors.py
+++ b/unittests/testerrors.py
@@ -21,6 +21,7 @@ from archivist.errors import (
     ArchivistForbiddenError,
     ArchivistNotFoundError,
     ArchivistNotImplementedError,
+    ArchivistPaymentRequiredError,
     ArchivistUnauthenticatedError,
     ArchivistUnavailableError,
 )
@@ -96,6 +97,28 @@ class TestErrors(TestCase):
         self.assertEqual(
             str(ex.exception),
             '{"error": "some error"} (401)',
+            msg="incorrect error",
+        )
+
+    def test_errors_402(self):
+        """
+        Test errors
+        """
+        response = MockResponse(
+            402, error="Entity QuotaReached", description="Current quota is 10"
+        )
+        error = _parse_response(response)
+
+        self.assertIsNotNone(
+            error,
+            msg="error should not be None",
+        )
+        with self.assertRaises(ArchivistPaymentRequiredError) as ex:
+            raise error
+
+        self.assertEqual(
+            str(ex.exception),
+            '{"error": "Entity QuotaReached", "description": "Current quota is 10"} (402)',
             msg="incorrect error",
         )
 


### PR DESCRIPTION
Problem:
A 402 will be unclear in the response.

Solution:
A specific exception is raised when receiving a 402.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>