### PR TITLE
A 429 is retried if retry-after is specified

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -56,6 +56,8 @@ from .errors import (
     ArchivistIllegalArgumentError,
     ArchivistNotFoundError,
 )
+from .headers import _headers_get
+from .retry429 import retry_429
 
 from .assets import _AssetsClient
 from .confirmer import MAX_TIME
@@ -207,6 +209,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return newheaders
 
+    @retry_429
     def get(
         self, subpath: str, identity: str, *, headers: Optional[Dict] = None
     ) -> Dict:
@@ -236,6 +239,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return response.json()
 
+    @retry_429
     def get_file(
         self,
         subpath: str,
@@ -279,6 +283,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return response
 
+    @retry_429
     def post(self, path: str, request: Dict, *, headers: Optional[Dict] = None) -> Dict:
         """POST method (REST)
 
@@ -308,6 +313,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return response.json()
 
+    @retry_429
     def post_file(self, path: str, fd: BinaryIO, mtype: str) -> Dict:
         """POST method (REST) - upload binary
 
@@ -347,6 +353,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return response.json()
 
+    @retry_429
     def delete(
         self, subpath: str, identity: str, *, headers: Optional[Dict] = None
     ) -> Dict:
@@ -378,6 +385,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return response.json()
 
+    @retry_429
     def patch(
         self,
         subpath: str,
@@ -417,6 +425,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
         return response.json()
 
+    @retry_429
     def __list(self, path, args, *, headers=None) -> Response:
         if args:
             path = "?".join((path, args))
@@ -527,7 +536,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
             headers=headers,
         )
 
-        return int(response.headers[HEADERS_TOTAL_COUNT])
+        return int(_headers_get(response.headers, HEADERS_TOTAL_COUNT))
 
     def list(
         self,

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -68,9 +68,7 @@ def _wait_for_confirmation(self, identity):
         return entity
 
     return None  # this line is unreachable to function that use it
-    # But will mess up any linters that use type hints
-    # Remember to ignore the return type if you use this
-    # Function
+    # But will mess up any linters that use type hints.
 
 
 def __on_giveup_confirmed(details):

--- a/archivist/constants.py
+++ b/archivist/constants.py
@@ -6,8 +6,10 @@
 ROOT = "archivist"
 SEP = "/"
 
-HEADERS_REQUEST_TOTAL_COUNT = "x-request-total-count"
-HEADERS_TOTAL_COUNT = "x-total-count"
+# define in MIME canonical form
+HEADERS_REQUEST_TOTAL_COUNT = "X-Request-Total-Count"
+HEADERS_TOTAL_COUNT = "X-Total-Count"
+HEADERS_RETRY_AFTER = "Archivist-Rate-Limit-Reset"
 
 CONFIRMATION_STATUS = "confirmation_status"
 CONFIRMATION_PENDING = "PENDING"

--- a/archivist/headers.py
+++ b/archivist/headers.py
@@ -1,0 +1,14 @@
+"""Archivist SDK
+
+   Manage headers allowing for upper/lower/canonicalize form
+"""
+
+
+def _headers_get(headers: dict, key: str) -> str:
+    if headers is not None:
+        ret = headers.get(key)
+        if ret is not None:
+            return ret
+        return headers.get(key.lower())
+
+    return None

--- a/archivist/retry429.py
+++ b/archivist/retry429.py
@@ -1,0 +1,36 @@
+"""retry when 429 is received
+
+   Retries after waiting for the time read from the retry-after header
+"""
+
+from functools import wraps
+import logging
+from time import sleep
+
+from .errors import ArchivistTooManyRequestsError
+
+NO_OF_RETRIES = 3
+LOGGER = logging.getLogger(__name__)
+
+
+def retry_429(f):
+    """
+    Retry when 429 received using sleep suggested by retry_after header
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        no_of_retries = NO_OF_RETRIES
+        while True:
+            try:
+                ret = f(*args, **kwargs)
+            except ArchivistTooManyRequestsError as ex:
+                if ex.retry <= 0 or no_of_retries <= 0:
+                    raise
+                sleep(ex.retry)
+                no_of_retries -= 1
+
+            else:
+                return ret
+
+    return wrapper

--- a/unittests/testarchivistdelete.py
+++ b/unittests/testarchivistdelete.py
@@ -1,0 +1,160 @@
+"""
+Test archivist
+"""
+
+from unittest import TestCase, mock
+
+from archivist.archivist import Archivist
+from archivist.constants import ROOT, HEADERS_RETRY_AFTER
+from archivist.errors import (
+    ArchivistNotFoundError,
+    ArchivistTooManyRequestsError,
+)
+
+from .mock_response import MockResponse
+
+
+# pylint: disable=unused-variable
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+
+
+class TestArchivistMethods(TestCase):
+    """
+    Test Archivist base method class
+    """
+
+    def setUp(self):
+        self.arch = Archivist("url", auth="authauthauth")
+
+
+class TestArchivistDelete(TestArchivistMethods):
+    """
+    Test Archivist Delete method
+    """
+
+    def test_delete(self):
+        """
+        Test default delete method
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200)
+            resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )
+
+    def test_delete_with_error(self):
+        """
+        Test delete method with error
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(404, identity="entity/xxxxxxxx")
+            with self.assertRaises(ArchivistNotFoundError):
+                resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+
+    def test_delete_with_headers(self):
+        """
+        Test default delete method
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200)
+            resp = self.arch.delete(
+                "path/path",
+                "id/xxxxxxxx",
+                headers={"headerfield1": "headervalue1"},
+            )
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    (f"url/{ROOT}/path/path/id/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            "headerfield1": "headervalue1",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )
+
+    def test_delete_with_429(self):
+        """
+        Test delete method with error
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.return_value = MockResponse(429)
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.delete(
+                    "path/path",
+                    "id/xxxxxxxx",
+                    headers={"headerfield1": "headervalue1"},
+                )
+
+    def test_delete_with_429_retry_and_fail(self):
+        """
+        Test delete method with 429 retry and fail
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+
+    def test_delete_with_429_retry_and_retries_fail(self):
+        """
+        Test delete method with 429 retry and retries_fail
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+
+    def test_delete_with_429_retry_and_success(self):
+        """
+        Test delete method with 429 retry and success
+        """
+        with mock.patch.object(self.arch._session, "delete") as mock_delete:
+            mock_delete.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(200),
+            )
+            resp = self.arch.delete("path/path", "entity/xxxxxxxx")
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )

--- a/unittests/testarchivistget.py
+++ b/unittests/testarchivistget.py
@@ -1,0 +1,315 @@
+"""
+Test archivist
+"""
+
+from io import BytesIO
+from unittest import TestCase, mock
+
+from archivist.archivist import Archivist
+from archivist.constants import ROOT, HEADERS_RETRY_AFTER
+from archivist.errors import (
+    ArchivistNotFoundError,
+    ArchivistTooManyRequestsError,
+)
+
+from .mock_response import MockResponse
+
+
+# pylint: disable=unused-variable
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+
+
+class TestArchivistMethods(TestCase):
+    """
+    Test Archivist base method class
+    """
+
+    def setUp(self):
+        self.arch = Archivist("url", auth="authauthauth")
+
+
+class TestArchivistGet(TestArchivistMethods):
+    """
+    Test Archivist Get method
+    """
+
+    def test_get(self):
+        """
+        Test default get method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200)
+            resp = self.arch.get("path/path", "entity/xxxxxxxx")
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+
+    def test_ring_buffer(self):
+        """
+        Test That the ring buffer for response objects works as expected
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200)
+            resp = self.arch.get("path/path", "entity/xxxxxxxx")
+            last_response = self.arch.last_response()
+            self.assertEqual(last_response, [mock_get.return_value])
+
+    def test_get_with_error(self):
+        """
+        Test get method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
+            with self.assertRaises(ArchivistNotFoundError):
+                resp = self.arch.get("path/path", "entity/xxxxxxxx")
+
+    def test_get_file(self):
+        """
+        Test default get method
+        """
+
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+
+            def iter_content():
+                i = 0
+
+                def filedata(chunk_size=4096):  # pylint: disable=unused-argument
+                    nonlocal i
+                    while i < 4:
+                        i += 1
+
+                        if i == 2:
+                            yield None
+
+                        yield b"chunkofbytes"
+
+                return filedata
+
+            mock_get.return_value = MockResponse(
+                200,
+                identity="entity/xxxxxxxx",
+                iter_content=iter_content(),
+            )
+            with BytesIO() as fd:
+                resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+                self.assertEqual(
+                    tuple(mock_get.call_args),
+                    (
+                        (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                            "stream": True,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_get_file_with_error(self):
+        """
+        Test get method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
+            with self.assertRaises(ArchivistNotFoundError):
+                with BytesIO() as fd:
+                    resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+
+    def test_get_file_with_429(self):
+        """
+        Test get method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(429)
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                with BytesIO() as fd:
+                    resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+
+    def test_get_file_with_429_retry_and_fail(self):
+        """
+        Test get method with 429 retry and fail
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                with BytesIO() as fd:
+                    resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+
+    def test_get_file_with_429_retry_and_retries_fail(self):
+        """
+        Test get method with 429 retry and retries_fail
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                with BytesIO() as fd:
+                    resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+
+    def test_get_file_with_429_retry_and_success(self):
+        """
+        Test get method with 429 retry and success
+        """
+
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+
+            def iter_content():
+                i = 0
+
+                def filedata(chunk_size=4096):  # pylint: disable=unused-argument
+                    nonlocal i
+                    while i < 4:
+                        i += 1
+
+                        if i == 2:
+                            yield None
+
+                        yield b"chunkofbytes"
+
+                return filedata
+
+            mock_get.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(
+                    200,
+                    identity="entity/xxxxxxxx",
+                    iter_content=iter_content(),
+                ),
+            )
+            with BytesIO() as fd:
+                resp = self.arch.get_file("path/path", "entity/xxxxxxxx", fd)
+                self.assertEqual(
+                    tuple(mock_get.call_args),
+                    (
+                        (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                        {
+                            "headers": {
+                                "content-type": "application/json",
+                                "authorization": "Bearer authauthauth",
+                            },
+                            "verify": True,
+                            "cert": None,
+                            "stream": True,
+                        },
+                    ),
+                    msg="GET method called incorrectly",
+                )
+
+    def test_get_with_headers(self):
+        """
+        Test default get method
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(200)
+            resp = self.arch.get(
+                "path/path",
+                "id/xxxxxxxx",
+                headers={"headerfield1": "headervalue1"},
+            )
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    (f"url/{ROOT}/path/path/id/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            "headerfield1": "headervalue1",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+
+    def test_get_with_429(self):
+        """
+        Test get method with error
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(429)
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.get(
+                    "path/path",
+                    "id/xxxxxxxx",
+                    headers={"headerfield1": "headervalue1"},
+                )
+
+    def test_get_with_429_retry_and_fail(self):
+        """
+        Test get method with 429 retry and fail
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.get("path/path", "entity/xxxxxxxx")
+
+    def test_get_with_429_retry_and_retries_fail(self):
+        """
+        Test get method with 429 retry and retries_fail
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.get("path/path", "entity/xxxxxxxx")
+
+    def test_get_with_429_retry_and_success(self):
+        """
+        Test get method with 429 retry and success
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(200),
+            )
+            resp = self.arch.get("path/path", "entity/xxxxxxxx")
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
+                    {
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -1,0 +1,358 @@
+"""
+Test archivist
+"""
+
+from io import BytesIO
+from unittest import TestCase, mock
+
+from archivist.archivist import Archivist
+from archivist.constants import ROOT, HEADERS_RETRY_AFTER
+from archivist.errors import (
+    ArchivistBadRequestError,
+    ArchivistTooManyRequestsError,
+)
+
+from .mock_response import MockResponse
+
+
+# pylint: disable=unused-variable
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+
+
+class TestArchivistMethods(TestCase):
+    """
+    Test Archivist base method class
+    """
+
+    def setUp(self):
+        self.arch = Archivist("url", auth="authauthauth")
+
+
+class TestArchivistPost(TestArchivistMethods):
+    """
+    Test Archivist POST method
+    """
+
+    def test_post(self):
+        """
+        Test default post method
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, request=request)
+            resp = self.arch.post("path/path", request)
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    (f"url/{ROOT}/path/path",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="POST method called incorrectly",
+            )
+
+    def test_post_with_error(self):
+        """
+        Test post method with error
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(400, request=request, field1="value1")
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.post("path/path", request)
+
+    def test_post_with_429(self):
+        """
+        Test post method with 429
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(429, request=request, field1="value1")
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.post("path/path", request)
+
+    def test_post_with_429_retry_and_fail(self):
+        """
+        Test post method with 429 retry and fail
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.post("path/path", request)
+
+    def test_post_with_429_retry_and_retries_fail(self):
+        """
+        Test post method with 429 retry and retries_fail
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.post("path/path", request)
+
+    def test_post_with_429_retry_and_success(self):
+        """
+        Test post method with 429 retry and success
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(200),
+            )
+            resp = self.arch.post("path/path", request)
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    (f"url/{ROOT}/path/path",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="POST method called incorrectly",
+            )
+
+    def test_post_with_headers(self):
+        """
+        Test default post method
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, request=request)
+            resp = self.arch.post(
+                "path/path",
+                request,
+                headers={"headerfield1": "headervalue1"},
+            )
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    (f"url/{ROOT}/path/path",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                            "authorization": "Bearer authauthauth",
+                            "headerfield1": "headervalue1",
+                        },
+                        "verify": True,
+                        "cert": None,
+                    },
+                ),
+                msg="POST method called incorrectly",
+            )
+
+    def test_post_file(self):
+        """
+        Test default post_file method
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200)
+            resp = self.arch.post_file(
+                "path/path",
+                BytesIO(b"lotsofbytes"),
+                "image/jpg",
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                len(args),
+                1,
+                msg="Incorrect number of arguments",
+            )
+            self.assertEqual(
+                args[0],
+                f"url/{ROOT}/path/path",
+                msg="Incorrect first argument",
+            )
+            self.assertEqual(
+                len(kwargs),
+                4,
+                msg="Incorrect number of keyword arguments",
+            )
+            headers = kwargs.get("headers")
+            self.assertNotEqual(
+                headers,
+                None,
+                msg="Header does not exist",
+            )
+            self.assertTrue(
+                headers["content-type"].startswith("multipart/form-data"),
+                msg="Incorrect content-type",
+            )
+            data = kwargs.get("data")
+            self.assertIsNotNone(
+                data,
+                msg="Incorrect data",
+            )
+            fields = data.fields
+            self.assertIsNotNone(
+                fields,
+                msg="Incorrect fields",
+            )
+            myfile = fields.get("file")
+            self.assertIsNotNone(
+                myfile,
+                msg="Incorrect file key",
+            )
+            self.assertEqual(
+                myfile[0],
+                "filename",
+                msg="Incorrect filename",
+            )
+            self.assertEqual(
+                myfile[2],
+                "image/jpg",
+                msg="Incorrect mimetype",
+            )
+
+    def test_post_file_with_error(self):
+        """
+        Test post method with error
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(400)
+            with self.assertRaises(ArchivistBadRequestError):
+                resp = self.arch.post_file(
+                    "path/path",
+                    BytesIO(b"lotsofbytes"),
+                    "image/jpg",
+                )
+
+    def test_post_file_with_429(self):
+        """
+        Test post method with error
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(429)
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.post_file(
+                    "path/path",
+                    BytesIO(b"lotsofbytes"),
+                    "image/jpg",
+                )
+
+    def test_post_file_with_429_retry_and_fail(self):
+        """
+        Test post method with 429 retry and fail
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.post_file(
+                    "path/path",
+                    BytesIO(b"lotsofbytes"),
+                    "image/jpg",
+                )
+
+    def test_post_file_with_429_retry_and_retries_fail(self):
+        """
+        Test post method with 429 retry and retries_fail
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+            )
+            with self.assertRaises(ArchivistTooManyRequestsError):
+                resp = self.arch.post_file(
+                    "path/path",
+                    BytesIO(b"lotsofbytes"),
+                    "image/jpg",
+                )
+
+    def test_post_file_with_429_retry_and_success(self):
+        """
+        Test post method with 429 retry and success
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.side_effect = (
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
+                MockResponse(200),
+            )
+            resp = self.arch.post_file(
+                "path/path",
+                BytesIO(b"lotsofbytes"),
+                "image/jpg",
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                len(args),
+                1,
+                msg="Incorrect number of arguments",
+            )
+            self.assertEqual(
+                args[0],
+                f"url/{ROOT}/path/path",
+                msg="Incorrect first argument",
+            )
+            self.assertEqual(
+                len(kwargs),
+                4,
+                msg="Incorrect number of keyword arguments",
+            )
+            headers = kwargs.get("headers")
+            self.assertNotEqual(
+                headers,
+                None,
+                msg="Header does not exist",
+            )
+            self.assertTrue(
+                headers["content-type"].startswith("multipart/form-data"),
+                msg="Incorrect content-type",
+            )
+            data = kwargs.get("data")
+            self.assertIsNotNone(
+                data,
+                msg="Incorrect data",
+            )
+            fields = data.fields
+            self.assertIsNotNone(
+                fields,
+                msg="Incorrect fields",
+            )
+            myfile = fields.get("file")
+            self.assertIsNotNone(
+                myfile,
+                msg="Incorrect file key",
+            )
+            self.assertEqual(
+                myfile[0],
+                "filename",
+                msg="Incorrect filename",
+            )
+            self.assertEqual(
+                myfile[2],
+                "image/jpg",
+                msg="Incorrect mimetype",
+            )

--- a/unittests/testerrors.py
+++ b/unittests/testerrors.py
@@ -22,6 +22,7 @@ from archivist.errors import (
     ArchivistNotFoundError,
     ArchivistNotImplementedError,
     ArchivistPaymentRequiredError,
+    ArchivistTooManyRequestsError,
     ArchivistUnauthenticatedError,
     ArchivistUnavailableError,
 )
@@ -198,6 +199,35 @@ class TestErrors(TestCase):
         self.assertEqual(
             str(ex.exception),
             "entity/xxxxx not found (404)",
+            msg="incorrect error",
+        )
+
+    def test_errors_429(self):
+        """
+        Test errors
+        """
+
+        class Object:
+            pass
+
+        request = Object()
+        request.body = json.dumps({"identity": "entity/xxxxx"})
+        response = MockResponse(
+            429,
+            request=request,
+            error="some error",
+        )
+        error = _parse_response(response)
+        self.assertIsNotNone(
+            error,
+            msg="error should not be None",
+        )
+        with self.assertRaises(ArchivistTooManyRequestsError) as ex:
+            raise error
+
+        self.assertEqual(
+            str(ex.exception),
+            '{"error": "some error"} (429)',
             msg="incorrect error",
         )
 


### PR DESCRIPTION
Problem:
A 429 indicates that submissions of requests is too rapid and
upstream has refused the request which should be retried later.

Solution:
If a 429 has a retry-after header then wait for the specified period
and try again up to a maximum of 3 times.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>