### PR TITLE
Raise UnimplementedError when cert option is used

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -33,7 +33,8 @@
 import logging
 
 import json
-from os.path import isfile as os_path_isfile
+
+# from os.path import isfile as os_path_isfile
 from typing import BinaryIO, Dict, List, Optional
 from collections import deque
 from copy import deepcopy
@@ -55,6 +56,7 @@ from .errors import (
     ArchivistDuplicateError,
     ArchivistIllegalArgumentError,
     ArchivistNotFoundError,
+    ArchivistNotImplementedError,
 )
 from .headers import _headers_get
 from .retry429 import retry_429
@@ -89,7 +91,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
     Args:
         url (str): URL of archivist endpoint
         auth: string representing JWT token.
-        cert: filepath containing both private key and certificate
+        cert: filepath containing both private key and certificate (not implemented)
         verify: if True the certificate is verified
         max_time (int): maximum time in seconds to wait for confirmation
 
@@ -128,8 +130,9 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
             )
 
         if cert:
-            if not os_path_isfile(cert):
-                raise ArchivistNotFoundError(f"Cert file {cert} does not exist")
+            raise ArchivistNotImplementedError("Cert option is not implemented")
+            # if not os_path_isfile(cert):
+            #    raise ArchivistNotFoundError(f"Cert file {cert} does not exist")
 
         self._cert = cert
         self._response_ring_buffer = deque(maxlen=self.RING_BUFFER_MAX_LEN)

--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -63,7 +63,7 @@ class Archivist4xxError(ArchivistError):
 
 
 class ArchivistNotImplementedError(ArchivistError):
-    """Illegal REST verb (501)"""
+    """Illegal REST verb (501) or option"""
 
 
 class ArchivistUnavailableError(ArchivistError):

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -13,6 +13,7 @@ from archivist.errors import (
     ArchivistDuplicateError,
     ArchivistIllegalArgumentError,
     ArchivistNotFoundError,
+    ArchivistNotImplementedError,
     ArchivistTooManyRequestsError,
 )
 
@@ -129,27 +130,32 @@ class TestArchivist(TestCase):
         with self.assertRaises(ArchivistIllegalArgumentError):
             arch = Archivist("url", auth="authauthauth", cert="/path/to/file")
 
-    @mock.patch("archivist.archivist.os_path_isfile")
-    def test_archivist_with_nonexistent_cert(self, mock_isfile):
+    # @mock.patch("archivist.archivist.os_path_isfile")
+    # def test_archivist_with_nonexistent_cert(self, mock_isfile):
+    def test_archivist_with_nonexistent_cert(self):
         """
         Test archivist creation with nonexistent cert
         """
-        mock_isfile.return_value = False
-        with self.assertRaises(ArchivistNotFoundError):
+        # mock_isfile.return_value = False
+        # with self.assertRaises(ArchivistNotFoundError):
+        with self.assertRaises(ArchivistNotImplementedError):
             arch = Archivist("url", cert="/path/to/file")
 
-    @mock.patch("archivist.archivist.os_path_isfile")
-    def test_archivist_with_existent_cert(self, mock_isfile):
+    # @mock.patch("archivist.archivist.os_path_isfile")
+    # def test_archivist_with_existent_cert(self, mock_isfile):
+    def test_archivist_with_existent_cert(self):
         """
-        Test archivist creation with cert
+        Test archivist creation with cert - not currently implemented
         """
-        mock_isfile.return_value = True
-        arch = Archivist("url", cert="/path/to/file")
-        self.assertEqual(
-            arch.cert,
-            "/path/to/file",
-            msg="verify must be False",
-        )
+        with self.assertRaises(ArchivistNotImplementedError):
+            arch = Archivist("url", cert="/path/to/file")
+        # mock_isfile.return_value = True
+        # arch = Archivist("url", cert="/path/to/file")
+        # self.assertEqual(
+        #    arch.cert,
+        #    "/path/to/file",
+        #    msg="verify must be False",
+        # )
 
 
 class TestArchivistMethods(TestCase):


### PR DESCRIPTION
Problem:
The cert keyword argument to Archivist() was never
implemented.

Solution:
Specifying cert will raise ArchivistNotImplemented error.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>