### PR TITLE
Loosen dependency requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ One can then use the examples code to create assets (see examples directory):
     from archivist.proof_mechanism import ProofMechanism
     
     # Oauth2 token that grants access
-    with open(".auth_token", mode='r') as tokenfile:
+    with open(".auth_token", mode='r', encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
     
     # Initialize connection to Archivist - the URL for production will be different to this URL

--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -9,7 +9,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -15,7 +15,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -9,7 +9,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -9,7 +9,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -26,6 +26,7 @@ def __lookup_max_time():
     return MAX_TIME
 
 
+# pylint: disable=consider-using-f-string
 def __backoff_handler(details):
     LOGGER.debug("MAX_TIME %s", MAX_TIME)
     LOGGER.debug(

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -9,7 +9,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -9,7 +9,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -10,7 +10,7 @@ from enum import Enum
 import logging
 from sys import exit as sys_exit
 
-from .archivist import Archivist
+from . import archivist
 from .logger import set_logger
 from .proof_mechanism import ProofMechanism
 
@@ -119,13 +119,15 @@ def endpoint(args):
     }
 
     if args.auth_token_file:
-        with open(args.auth_token_file, mode="r") as tokenfile:
+        with open(args.auth_token_file, mode="r", encoding="utf-8") as tokenfile:
             authtoken = tokenfile.read().strip()
 
-        arch = Archivist(args.url, auth=authtoken, verify=False, fixtures=fixtures)
+        arch = archivist.Archivist(
+            args.url, auth=authtoken, verify=False, fixtures=fixtures
+        )
 
     elif args.client_cert_name:
-        arch = Archivist(
+        arch = archivist.Archivist(
             args.url, cert=args.client_cert_name, verify=False, fixtures=fixtures
         )
 

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -9,7 +9,7 @@
 
    .. code-block:: python
 
-      with open(".auth_token", mode="r") as tokenfile:
+      with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
           authtoken = tokenfile.read().strip()
 
       # Initialize connection to Archivist

--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -15,7 +15,7 @@ and locations.
     from archivist.proof_mechanism import ProofMechanism
     
     # Oauth2 token that grants access
-    with open(".auth_token", mode='r') as tokenfile:
+    with open(".auth_token", mode='r', encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
     
     # Initialize connection to Archivist - for assets on DLT.

--- a/examples/access_policies_filter.py
+++ b/examples/access_policies_filter.py
@@ -12,7 +12,7 @@ from archivist.archivist import Archivist
 
 def main():
     """Main function of filtering access_policies."""
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/examples/access_policy_create.py
+++ b/examples/access_policy_create.py
@@ -17,7 +17,7 @@ def main():
     create an example archivist connection and create an asset.
 
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     arch = Archivist(

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -71,7 +71,7 @@ def main():
     create an example archivist connection and create an asset.
 
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist. max_time is the time to wait for confirmation

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -107,7 +107,7 @@ def main():
     the asset and fetch the event.
 
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/examples/filter_assets.py
+++ b/examples/filter_assets.py
@@ -18,7 +18,7 @@ def main():
     attributes to filter all assets of the selected properties and
     attributes through function get_matching_assets.
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/examples/filter_events.py
+++ b/examples/filter_events.py
@@ -17,7 +17,7 @@ def main():
     attributes to filter all events of the selected properties.
 
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/examples/get_asset.py
+++ b/examples/get_asset.py
@@ -18,7 +18,7 @@ def main():
     Parse in user input of url and auth token and use them to
     create an example archivist connection and fetch all assets.
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/examples/subject_create.py
+++ b/examples/subject_create.py
@@ -16,7 +16,7 @@ def main():
     create an example archivist connection and create an asset.
 
     """
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/examples/subjects_filter.py
+++ b/examples/subjects_filter.py
@@ -12,7 +12,7 @@ from archivist.archivist import Archivist
 
 def main():
     """Main function of filtering subjects."""
-    with open(".auth_token", mode="r") as tokenfile:
+    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
         authtoken = tokenfile.read().strip()
 
     # Initialize connection to Archivist

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -64,7 +64,7 @@ class TestAccessPolicies(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with open(environ["TEST_AUTHTOKEN_FILENAME"]) as fd:
+        with open(environ["TEST_AUTHTOKEN_FILENAME"], encoding="utf-8") as fd:
             auth = fd.read().strip()
         cls.arch = Archivist(environ["TEST_ARCHIVIST"], auth=auth, verify=False)
         cls.props = deepcopy(PROPS)

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -32,7 +32,7 @@ class TestAssetCreate(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with open(environ["TEST_AUTHTOKEN_FILENAME"]) as fd:
+        with open(environ["TEST_AUTHTOKEN_FILENAME"], encoding="utf-8") as fd:
             auth = fd.read().strip()
         cls.arch = Archivist(
             environ["TEST_ARCHIVIST"], auth=auth, verify=False, max_time=300

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -25,7 +25,7 @@ class TestAssetCreate(TestCase):
 
     @classmethod
     def setUp(cls):
-        with open(environ["TEST_AUTHTOKEN_FILENAME"]) as fd:
+        with open(environ["TEST_AUTHTOKEN_FILENAME"], encoding="utf-8") as fd:
             auth = fd.read().strip()
         cls.arch = Archivist(environ["TEST_ARCHIVIST"], auth=auth, verify=False)
         cls.file_uuid: str = ""

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -31,7 +31,7 @@ class TestSubjects(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with open(environ["TEST_AUTHTOKEN_FILENAME"]) as fd:
+        with open(environ["TEST_AUTHTOKEN_FILENAME"], encoding="utf-8") as fd:
             auth = fd.read().strip()
         cls.arch = Archivist(environ["TEST_ARCHIVIST"], auth=auth, verify=False)
         cls.display_name = f"{DISPLAY_NAME} {uuid4()}"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
 
 # code quality
-autopep8==1.5.5
-black==21.4b2
-coverage==5.4
-pycodestyle==2.6.0
-pylint==2.6.0
+autopep8~=1.5
+black~=21.4b2
+coverage~=5.4
+pycodestyle~=2.6
+pylint~=2.6
 
 # uploading to pypi
-twine==3.4.1
+twine~=3.4
 
 # documentation
-sphinx==3.5.4
-sphinx-rtd-theme==0.5.2
+sphinx~=3.5
+sphinx-rtd-theme~=0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-backoff==1.10.0
-certifi==2020.12.5
-flatten-dict==0.3.0
-iso8601==0.1.13
-requests==2.22.0
-requests-toolbelt==0.9.1
-rfc3339==6.2
+backoff~=1.10
+certifi
+flatten-dict~=0.3.0
+iso8601~=0.1.13
+requests~=2.22
+requests-toolbelt~=0.9
+rfc3339~=6.2

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ HERE = os.path.dirname(__file__)
 REPO_URL = 'https://github.com/jitsuin-inc/archivist-python/'
 NAME = "jitsuin-archivist"
 
-with open(os.path.join(HERE, 'README.rst')) as FF:
+with open(os.path.join(HERE, 'README.rst'), encoding="utf-8") as FF:
     DESC = FF.read()
 
-with open(os.path.join(HERE, 'requirements.txt')) as FF:
+with open(os.path.join(HERE, 'requirements.txt'), encoding="utf-8") as FF:
     requirements=[f"{line.strip()}" for line in FF]
 
 setup(


### PR DESCRIPTION
Problem:
Installation of other packages caused collisions on differing
requirements dependencies - specifically requests and urllib3

Solution:
Specify a range of dependencies in the requrements.txt file.
Additionally this caused new chacks to fail regarding the encoding when
opening a file - see PEP 597. This packaghe should now run on windows.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>