### PR TITLE
Various type hint improvements

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 from .constants import (
     SEP,

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -29,7 +29,7 @@ from archivist.type_aliases import NoneOnError
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 
 from .constants import (
@@ -186,7 +186,7 @@ class _AssetsClient:
         """
         confirmer.MAX_TIME = self._archivist.max_time
         # pylint: disable=protected-access
-        return confirmer._wait_for_confirmation(self, identity)  # type: ignore
+        return confirmer._wait_for_confirmation(self, identity)
 
     def read(self, identity: str) -> Asset:
         """Read asset

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -31,7 +31,7 @@ from requests.models import Response
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 from .constants import ATTACHMENTS_SUBPATH, ATTACHMENTS_LABEL
 

--- a/archivist/compliance.py
+++ b/archivist/compliance.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 
 from .constants import (

--- a/archivist/compliance_policies.py
+++ b/archivist/compliance_policies.py
@@ -31,7 +31,7 @@ from typing import Dict, Optional, Union
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 from .compliance_policy_requests import (
     CompliancePolicySince,

--- a/archivist/compliance_policy_type.py
+++ b/archivist/compliance_policy_type.py
@@ -16,7 +16,7 @@ class CompliancePolicyType(Enum):
     COMPLIANCE_TYPE_UNDEFINED = 0
     #: Time since specific event for specified period
     COMPLIANCE_SINCE = 1
-    #: Unresolved event currently on asset (eg. vulnerablity)
+    #: Unresolved event currently on asset (eg. vulnerability)
     COMPLIANCE_CURRENT_OUTSTANDING = 2
     #: No unresolved events for longer than specified period
     COMPLIANCE_PERIOD_OUTSTANDING = 3

--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -52,7 +52,7 @@ class ArchivistNotFoundError(ArchivistError):
 
 
 class ArchivistTooManyRequestsError(ArchivistError):
-    """Too many reqests in too short a time (429)"""
+    """Too many requests in too short a time (429)"""
 
     def __init__(self, retry: Optional[str], *args):
         self.retry = float(retry) if retry is not None else 0
@@ -65,6 +65,10 @@ class Archivist4xxError(ArchivistError):
 
 class ArchivistNotImplementedError(ArchivistError):
     """Illegal REST verb (501) or option"""
+
+
+class ArchivistHeaderError(ArchivistError):
+    """When the expected header is not received"""
 
 
 class ArchivistUnavailableError(ArchivistError):

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -28,7 +28,7 @@ from copy import deepcopy
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 from .constants import (
     SEP,
@@ -193,7 +193,7 @@ class _EventsClient:
         """
         confirmer.MAX_TIME = self._archivist.max_time
         # pylint: disable=protected-access
-        return confirmer._wait_for_confirmation(self, identity)  # type: ignore
+        return confirmer._wait_for_confirmation(self, identity)
 
     def read(self, identity: str) -> Event:
         """Read event

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -27,7 +27,7 @@ from typing import Dict, Optional
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 from .constants import LOCATIONS_SUBPATH, LOCATIONS_LABEL
 from .dictmerge import _deepmerge

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-import archivist as type_helper
+from . import archivist as type_helper
 
 from .constants import (
     SUBJECTS_SUBPATH,

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -11,6 +11,7 @@ from archivist.errors import (
     ArchivistBadFieldError,
     ArchivistBadRequestError,
     ArchivistDuplicateError,
+    ArchivistHeaderError,
     ArchivistIllegalArgumentError,
     ArchivistNotFoundError,
     ArchivistNotImplementedError,
@@ -360,6 +361,23 @@ class TestArchivistCount(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistBadRequestError):
+                count = self.arch.count("path/path")
+
+    def test_count_with_missing_count_error(self):
+        """
+        Tests the default count method raises a ArchivistHeaderError when the
+        expected count header field is missing
+        """
+        with mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_get.return_value = MockResponse(
+                200,
+                things=[
+                    {
+                        "field1": "value1",
+                    },
+                ],
+            )
+            with self.assertRaises(ArchivistHeaderError):
                 count = self.arch.count("path/path")
 
     def test_count_with_429(self):

--- a/unittests/testcompliance_policy_type.py
+++ b/unittests/testcompliance_policy_type.py
@@ -17,7 +17,7 @@ class TestCompliancePolicyType(TestCase):
 
     def test_compliance_policy_type(self):
         """
-        Test ompliance policy type
+        Test compliance policy type
         """
         self.assertEqual(
             CompliancePolicyType.COMPLIANCE_SINCE.value, 1, msg="Incorrect value"


### PR DESCRIPTION
**problem**
#69 

Type hints are out of date

**Solution**
- _wait_for_confirmation make use of overload decorators,  removing the need for #type: ignore in two places
- Archivist.count now checks that the count field in headers is present before casting the value to an int  
- Made all imports of archivist local
- Fixed some typos in comments 


**signed off**

Serhiy1@live.co.uk

