### PR TITLE
Default page size has fixed value

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -39,11 +39,6 @@ from .dictmerge import _deepmerge
 
 from .assets import Asset
 
-#: Default page size - number of entities fetched in one REST GET in the
-#: :func:`~_AccessPoliciesClient.list` method. This can be overridden but should rarely
-#: be changed.
-DEFAULT_PAGE_SIZE = 500
-
 FIXTURE_LABEL = "access_policies"
 
 
@@ -208,7 +203,7 @@ class _AccessPoliciesClient:
         )
 
     def list(
-        self, *, page_size: int = DEFAULT_PAGE_SIZE, display_name: Optional[str] = None
+        self, *, page_size: Optional[int] = None, display_name: Optional[str] = None
     ):
         """List access policies.
 
@@ -251,7 +246,7 @@ class _AccessPoliciesClient:
         )
 
     def list_matching_assets(
-        self, access_policy_id: str, *, page_size: int = DEFAULT_PAGE_SIZE
+        self, access_policy_id: str, *, page_size: Optional[int] = None
     ):
         """List matching assets.
 
@@ -291,7 +286,7 @@ class _AccessPoliciesClient:
         )
 
     def list_matching_access_policies(
-        self, asset_id: str, *, page_size: int = DEFAULT_PAGE_SIZE
+        self, asset_id: str, *, page_size: Optional[int] = None
     ):
         """List matching access policies.
 

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -589,7 +589,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         path: str,
         field: str,
         *,
-        page_size: int = None,
+        page_size: Optional[int] = None,
         query: Optional[Dict] = None,
         headers: Optional[Dict] = None,
     ):

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -41,11 +41,6 @@ from . import confirmer
 from .dictmerge import _deepmerge
 from .errors import ArchivistNotFoundError
 
-#: Default page size - number of entities fetched in one REST GET in the
-#: :func:`~_AssetsClient.list` method. This can be overridden but should rarely
-#: be changed.
-DEFAULT_PAGE_SIZE = 500
-
 # These are now hardcoded and not user-selectable. Eventually they will be removed from
 # the backend API and removed from this package.
 BEHAVIOURS = [
@@ -259,7 +254,7 @@ class _AssetsClient:
     def list(
         self,
         *,
-        page_size: int = DEFAULT_PAGE_SIZE,
+        page_size: Optional[int] = None,
         props: Optional[Dict] = None,
         attrs: Optional[Dict] = None,
     ):

--- a/archivist/compliance_policies.py
+++ b/archivist/compliance_policies.py
@@ -47,11 +47,6 @@ from .constants import (
 )
 from .dictmerge import _deepmerge
 
-
-#: Default page size - number of entities fetched in one call to the
-#: :func:`~_AssetsClient.list` method.
-DEFAULT_PAGE_SIZE = 500
-
 FIXTURE_LABEL = "compliance_policies"
 
 
@@ -193,7 +188,7 @@ class _CompliancePoliciesClient:
             query=self.__query(props),
         )
 
-    def list(self, *, page_size: int = DEFAULT_PAGE_SIZE, props: Dict = None):
+    def list(self, *, page_size: Optional[int] = None, props: Dict = None):
         """List compliance policies.
 
         Lists compliance policies that match criteria.

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -42,11 +42,6 @@ from .dictmerge import _deepmerge
 from .errors import ArchivistNotFoundError
 
 
-#: Default page size - number of entities fetched in one REST GET in the
-#: :func:`~_EventsClient.list` method. This can be overridden but should rarely
-#: be changed.
-DEFAULT_PAGE_SIZE = 500
-
 FIXTURE_LABEL = "events"
 
 LOGGER = logging.getLogger(__name__)
@@ -296,7 +291,7 @@ class _EventsClient:
         self,
         *,
         asset_id: str = ASSETS_WILDCARD,
-        page_size: int = DEFAULT_PAGE_SIZE,
+        page_size: Optional[int] = None,
         props: Optional[Dict] = None,
         attrs: Optional[Dict] = None,
         asset_attrs: Optional[Dict] = None,

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -33,11 +33,6 @@ from .constants import LOCATIONS_SUBPATH, LOCATIONS_LABEL
 from .dictmerge import _deepmerge
 
 
-#: Default page size - number of entities fetched in one REST GET in the
-#: :func:`~_LocationsClient.list` method. This can be overridden but should rarely
-#: be changed.
-DEFAULT_PAGE_SIZE = 500
-
 FIXTURE_LABEL = "locations"
 
 
@@ -150,7 +145,7 @@ class _LocationsClient:
     def list(
         self,
         *,
-        page_size: int = DEFAULT_PAGE_SIZE,
+        page_size: Optional[int] = None,
         props: Optional[Dict] = None,
         attrs: Optional[Dict] = None,
     ):

--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -46,11 +46,6 @@ from .constants import (
 from .dictmerge import _deepmerge
 from .sbommetadata import SBOM
 
-#: Default page size - number of entities fetched in one REST GET in the
-#: :func:`~_AssetsClient.list` method. This can be overridden but should rarely
-#: be changed.
-DEFAULT_PAGE_SIZE = 50
-
 LOGGER = logging.getLogger(__name__)
 
 FIXTURE_LABEL = "sboms"
@@ -142,7 +137,7 @@ class _SBOMSClient:
     def list(
         self,
         *,
-        page_size: int = DEFAULT_PAGE_SIZE,
+        page_size: Optional[int] = None,
         metadata: Optional[Dict] = None,
     ):
         """List SBOMS.

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -34,11 +34,6 @@ from .constants import (
 )
 from .dictmerge import _deepmerge
 
-#: Default page size - number of entities fetched in one REST GET in the
-#: :func:`~_SubjectsClient.list` method. This can be overridden but should rarely
-#: be changed.
-DEFAULT_PAGE_SIZE = 500
-
 FIXTURE_LABEL = "subjects"
 
 
@@ -216,7 +211,7 @@ class _SubjectsClient:
     def list(
         self,
         *,
-        page_size: int = DEFAULT_PAGE_SIZE,
+        page_size: Optional[int] = None,
         display_name: Optional[str] = None,
     ):
         """List subjects.

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -15,7 +15,6 @@ from archivist.constants import (
     ASSETS_LABEL,
 )
 from archivist.errors import ArchivistBadRequestError
-from archivist.access_policies import DEFAULT_PAGE_SIZE
 
 from .mock_response import MockResponse
 from .testassets import RESPONSE as ASSET
@@ -316,7 +315,7 @@ class TestAccessPolicies(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
                                 "content-type": "application/json",
@@ -365,8 +364,7 @@ class TestAccessPolicies(TestCase):
                         (
                             (
                                 f"url/{ROOT}/{SUBPATH}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&display_name=Policy display name"
+                                "?display_name=Policy display name"
                             ),
                         ),
                         {
@@ -456,8 +454,7 @@ class TestAccessPolicies(TestCase):
                     (
                         (
                             f"url/{ROOT}/"
-                            f"{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
-                            f"?page_size={DEFAULT_PAGE_SIZE}",
+                            f"{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}",
                         ),
                         {
                             "headers": {
@@ -542,8 +539,7 @@ class TestAccessPolicies(TestCase):
                     tuple(a),
                     (
                         (
-                            f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
-                            f"?page_size={DEFAULT_PAGE_SIZE}",
+                            f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}",
                         ),
                         {
                             "headers": {

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -7,7 +7,7 @@ import json
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
-from archivist.assets import BEHAVIOURS, DEFAULT_PAGE_SIZE
+from archivist.assets import BEHAVIOURS
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
@@ -583,7 +583,7 @@ class TestAssets(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
                                 "content-type": "application/json",
@@ -635,8 +635,7 @@ class TestAssets(TestCase):
                         (
                             (
                                 f"url/{ROOT}/{SUBPATH}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&attributes.arc_firmware_version=1.0"
+                                "?attributes.arc_firmware_version=1.0"
                                 "&confirmation_status=CONFIRMED"
                             ),
                         ),

--- a/unittests/testcompliance_policies.py
+++ b/unittests/testcompliance_policies.py
@@ -16,7 +16,6 @@ from archivist.constants import (
 from archivist.errors import ArchivistBadRequestError
 from archivist.compliance_policies import (
     CompliancePolicy,
-    DEFAULT_PAGE_SIZE,
 )
 from archivist.compliance_policy_requests import (
     CompliancePolicySince,
@@ -286,7 +285,7 @@ class TestCompliancePolicies(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
                                 "content-type": "application/json",
@@ -332,13 +331,7 @@ class TestCompliancePolicies(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&compliance_type=SINCE"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}?compliance_type=SINCE"),),
                         {
                             "headers": {
                                 "content-type": "application/json",

--- a/unittests/testevents.py
+++ b/unittests/testevents.py
@@ -17,7 +17,7 @@ from archivist.constants import (
     HEADERS_TOTAL_COUNT,
 )
 from archivist.errors import ArchivistNotFoundError, ArchivistUnconfirmedError
-from archivist.events import Event, DEFAULT_PAGE_SIZE
+from archivist.events import Event
 
 from .mock_response import MockResponse
 
@@ -750,7 +750,6 @@ class TestEvents(TestCase):
                                 f"url/{ROOT}/{ASSETS_SUBPATH}"
                                 f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                                 f"/{EVENTS_LABEL}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
                             ),
                         ),
                         {
@@ -807,8 +806,7 @@ class TestEvents(TestCase):
                                 f"url/{ROOT}/{ASSETS_SUBPATH}"
                                 f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                                 f"/{EVENTS_LABEL}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&confirmation_status=CONFIRMED"
+                                "?confirmation_status=CONFIRMED"
                                 "&event_attributes.arc_firmware_version=1.0"
                             ),
                         ),
@@ -865,8 +863,7 @@ class TestEvents(TestCase):
                                 f"url/{ROOT}/{ASSETS_SUBPATH}"
                                 f"/{ASSETS_WILDCARD}"
                                 f"/{EVENTS_LABEL}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&confirmation_status=CONFIRMED"
+                                "?confirmation_status=CONFIRMED"
                                 "&event_attributes.arc_firmware_version=1.0"
                             ),
                         ),

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -14,7 +14,6 @@ from archivist.constants import (
     LOCATIONS_LABEL,
 )
 from archivist.errors import ArchivistBadRequestError
-from archivist.locations import DEFAULT_PAGE_SIZE
 
 from .mock_response import MockResponse
 
@@ -269,7 +268,7 @@ class TestLocations(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
                                 "content-type": "application/json",
@@ -319,8 +318,7 @@ class TestLocations(TestCase):
                         (
                             (
                                 f"url/{ROOT}/{SUBPATH}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&attributes.director=John Smith"
+                                "?attributes.director=John Smith"
                                 "&display_name=Macclesfield, Cheshire"
                             ),
                         ),

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -8,7 +8,6 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.sbommetadata import SBOM
-from archivist.sboms import DEFAULT_PAGE_SIZE
 from archivist.constants import (
     ROOT,
     SBOMS_SUBPATH,
@@ -290,9 +289,7 @@ class TestSBOMS(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            f"url/{ROOT}/{SUBPATH}/{SBOMS_WILDCARD}?page_size={DEFAULT_PAGE_SIZE}",
-                        ),
+                        (f"url/{ROOT}/{SUBPATH}/{SBOMS_WILDCARD}",),
                         {
                             "headers": {
                                 "content-type": "application/json",
@@ -344,8 +341,7 @@ class TestSBOMS(TestCase):
                         (
                             (
                                 f"url/{ROOT}/{SUBPATH}/{SBOMS_WILDCARD}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&lifecycle_status=ACTIVE"
+                                "?lifecycle_status=ACTIVE"
                                 "&version=10.0.2"
                             ),
                         ),

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -14,7 +14,6 @@ from archivist.constants import (
     SUBJECTS_LABEL,
 )
 from archivist.errors import ArchivistBadRequestError
-from archivist.subjects import DEFAULT_PAGE_SIZE
 
 from .mock_response import MockResponse
 
@@ -287,7 +286,7 @@ class TestSubjects(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (f"url/{ROOT}/{SUBPATH}?page_size={DEFAULT_PAGE_SIZE}",),
+                        (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
                                 "content-type": "application/json",
@@ -336,8 +335,7 @@ class TestSubjects(TestCase):
                         (
                             (
                                 f"url/{ROOT}/{SUBPATH}"
-                                f"?page_size={DEFAULT_PAGE_SIZE}"
-                                "&display_name=Subject display name"
+                                "?display_name=Subject display name"
                             ),
                         ),
                         {


### PR DESCRIPTION
Problem:
The pythonSDK specified a fixed default page size instead of
defaulting to whatever uostream has defined.

Solution:
Remove DEFAULT_PAGE_SIZE constants and set default page size to
None.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>