### PR TITLE
Filter subjects on display name

### DIFF
--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -217,7 +217,6 @@ class _SubjectsClient:
         """List subjects.
 
         List subjects that match criteria.
-        TODO: filtering on display_name does not currently work
 
         Args:
             display_name (str): display name (optional)

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -2,6 +2,7 @@
 Test subjects
 """
 
+from json import dumps as json_dumps
 from os import environ
 from unittest import TestCase
 from uuid import uuid4
@@ -93,14 +94,16 @@ class TestSubjects(TestCase):
         """
         Test subject list
         """
-        # TODO: filtering on display_name does not currently work...
         subjects = self.arch.subjects.list(display_name=self.display_name)
+        for i, subject in enumerate(subjects):
+            print(i, ":", json_dumps(subject, indent=4))
+
         for subject in subjects:
-            # self.assertEqual(
-            #    subject["display_name"],
-            #    self.display_name,
-            #    msg="Incorrect display name",
-            # )
+            self.assertEqual(
+                subject["display_name"],
+                self.display_name,
+                msg="Incorrect display name",
+            )
             self.assertGreater(
                 len(subject["display_name"]),
                 0,


### PR DESCRIPTION
Problem:
Common practice is to be able to get subjects by
display name as well as identity.

Solution:
Archivist allows filtering on display name and this has
been enabled here (whereas before it was commented out)

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>