### PR TITLE
Custom docs domain

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,3 +39,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: "./docs/_build/html"
+        cname: python.rkvst.com


### PR DESCRIPTION
Problem:
The custom domain was reset on every publish.

Solution:
Add cname directive to publish workflow.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>