### PR TITLE
Example code still used simple authtoken

### DIFF
--- a/archivist/errors.py
+++ b/archivist/errors.py
@@ -23,6 +23,14 @@ class ArchivistUnconfirmedError(ArchivistError):
     """asset or event failed to confirm after fixed timeout"""
 
 
+class ArchivistUnpublishedError(ArchivistError):
+    """Sbom failed to publish after fixed timeout"""
+
+
+class ArchivistUnwithdrawnError(ArchivistError):
+    """Sbom failed to be withdrawn after fixed timeout"""
+
+
 class ArchivistIllegalArgumentError(ArchivistError):
     """Optional keyword arguments are inconsistent"""
 

--- a/archivist/publisher.py
+++ b/archivist/publisher.py
@@ -1,0 +1,73 @@
+"""publisher interface
+
+   Wrap base methods with constants for assets (path, etc...
+"""
+
+import logging
+
+from typing import overload
+
+import backoff
+
+from .errors import ArchivistUnpublishedError
+
+
+# pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
+# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+from . import sboms
+
+MAX_TIME = 1200
+
+LOGGER = logging.getLogger(__name__)
+
+
+def __lookup_max_time():
+    return MAX_TIME
+
+
+# pylint: disable=consider-using-f-string
+def __backoff_handler(details):
+    LOGGER.debug("MAX_TIME %s", MAX_TIME)
+    LOGGER.debug(
+        "Backing off {wait:0.1f} seconds afters {tries} tries "
+        "calling function {target} with args {args} and kwargs "
+        "{kwargs}".format(**details)
+    )
+
+
+def __on_giveup_publication(details):
+    identity = details["args"][1]
+    elapsed = details["elapsed"]
+    raise ArchivistUnpublishedError(
+        f"publication for {identity} timed out after {elapsed} seconds"
+    )
+
+
+# These overloads are used for type hinting, if self is sboms client then
+# an SBOM metadata will be returned.
+# Overloads are evaluated at startup but not at runtime, therefore
+# no test coverage be done directly.
+
+
+@overload
+def _wait_for_publication(
+    self: "sboms._SbomsClient", identity: str
+) -> "sbommetadata.SBOM":
+    ...  # pragma: no cover
+
+
+@backoff.on_predicate(
+    backoff.expo,
+    logger=LOGGER,
+    max_time=__lookup_max_time,
+    on_backoff=__backoff_handler,
+    on_giveup=__on_giveup_publication,
+)
+def _wait_for_publication(self, identity):
+    """docstring"""
+    entity = self.read(identity)
+
+    if entity.published_date:
+        return entity
+
+    return None

--- a/archivist/withdrawer.py
+++ b/archivist/withdrawer.py
@@ -1,0 +1,73 @@
+"""withdrawer interface
+
+   Wrap base methods with constants for assets (path, etc...
+"""
+
+import logging
+
+from typing import overload
+
+import backoff
+
+from .errors import ArchivistUnwithdrawnError
+
+
+# pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
+# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+from . import sboms
+
+MAX_TIME = 1200
+
+LOGGER = logging.getLogger(__name__)
+
+
+def __lookup_max_time():
+    return MAX_TIME
+
+
+# pylint: disable=consider-using-f-string
+def __backoff_handler(details):
+    LOGGER.debug("MAX_TIME %s", MAX_TIME)
+    LOGGER.debug(
+        "Backing off {wait:0.1f} seconds afters {tries} tries "
+        "calling function {target} with args {args} and kwargs "
+        "{kwargs}".format(**details)
+    )
+
+
+def __on_giveup_withdrawn(details):
+    identity = details["args"][1]
+    elapsed = details["elapsed"]
+    raise ArchivistUnwithdrawnError(
+        f"withdrawn for {identity} timed out after {elapsed} seconds"
+    )
+
+
+# These overloads are used for type hinting, if self is sboms client then
+# an SBOM metadata will be returned.
+# Overloads are evaluated at startup but not at runtime, therefore
+# no test coverage be done directly.
+
+
+@overload
+def _wait_for_publication(
+    self: "sboms._SbomsClient", identity: str
+) -> "sbommetadata.SBOM":
+    ...  # pragma: no cover
+
+
+@backoff.on_predicate(
+    backoff.expo,
+    logger=LOGGER,
+    max_time=__lookup_max_time,
+    on_backoff=__backoff_handler,
+    on_giveup=__on_giveup_withdrawn,
+)
+def _wait_for_withdrawn(self, identity):
+    """docstring"""
+    entity = self.read(identity)
+
+    if entity.withdrawn_date:
+        return entity
+
+    return None

--- a/examples/access_policies_filter.py
+++ b/examples/access_policies_filter.py
@@ -1,24 +1,35 @@
-"""Filter IAM access_policies of a archivist connection given url to Archivist and user Token.
+"""Filter IAM access_policies of a archivist connection given url to Archivist
+and user Token.
 
-Main function parses in a url to the Archivist and a token, which is a user authorization.
-The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.access_policies.list() with suitable properties and
-attributes.
+Main function parses in a url to the Archivist and client credentials , which is
+a user authorization. The main function would initialize an archivist connection
+using the url and the credentials, called "arch", then call arch.access_policies.list()
+with suitable properties and attributes.
 
 """
+from os import getenv
 
 from archivist.archivist import Archivist
 
 
 def main():
     """Main function of filtering access_policies."""
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
 
     # count access_policies...

--- a/examples/access_policy_create.py
+++ b/examples/access_policy_create.py
@@ -1,11 +1,13 @@
 """Create a IAM access_policy given url to Archivist and user Token.
 
 Main function parses in
-a url to the Archivist and a token, which is a user authorization.
+a url to the Archivist and client credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.access_policys.create() and the access_policy
+the credentials, called "arch", then call arch.access_policies.create() and the access_policy
 will be created.
 """
+
+from os import getenv
 
 from archivist.archivist import Archivist
 
@@ -17,12 +19,20 @@ def main():
     create an example archivist connection and create an asset.
 
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
 
     props = {

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -1,10 +1,12 @@
 """Create an asset given url to Archivist and user Token.
 
 The module contains two functions: main and create_asset. Main function parses in
-a url to the Archivist and a token, which is a user authorization.
+a url to the Archivist and credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.assets.create() and the asset will be created.
+the credentials, called "arch", then call arch.assets.create() and the asset will be created.
 """
+
+from os import getenv
 
 from archivist.archivist import Archivist
 from archivist.proof_mechanism import ProofMechanism
@@ -67,12 +69,21 @@ def create_asset(arch):
 def main():
     """Main function of create asset.
 
-    Parse in user input of url and auth token and use them to
+    Parse in user input of url and client id/secrets and use them to
     create an example archivist connection and create an asset.
 
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist. max_time is the time to wait for confirmation
     # of an asset or event creation - the default is 1200 seconds but one can optionally
@@ -80,7 +91,7 @@ def main():
     # (rather than KHIPU) as confirmation times are much shorter in this case.
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
         max_time=300,
     )
     # Create a new asset

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -1,13 +1,14 @@
 """Create an event for an asset given url to Archivist and user Token.
 
 The module contains four functions: main, create_asset and create_event.
-Main function parses in a url to the Archivist and a token, which is a user authorization.
+Main function parses in a url to the Archivist and credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call create_assets and pass in "arch" and
+the credentials, called "arch", then call create_assets and pass in "arch" and
 create_assets will build create_asset, which is a archivist connection function
 to create a new asset for the archivist through archivist connection. The main funciton then
 calls create_event and pass in "arch" and the created asset to create a new event for the asset.
 """
+from os import getenv
 
 from archivist.archivist import Archivist
 
@@ -107,13 +108,21 @@ def main():
     the asset and fetch the event.
 
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
     # Create a new asset
     asset = create_asset(arch)

--- a/examples/filter_assets.py
+++ b/examples/filter_assets.py
@@ -1,11 +1,13 @@
 """Filter assets of a archivist connection given url to Archivist and user Token.
 
-Main function parses in a url to the Archivist and a token, which is a user authorization.
+Main function parses in a url to the Archivist and credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.assets.list() with suitable properties and
+the credentials, called "arch", then call arch.assets.list() with suitable properties and
 attributes.
 
 """
+
+from os import getenv
 
 from archivist.archivist import Archivist
 
@@ -13,18 +15,26 @@ from archivist.archivist import Archivist
 def main():
     """Main function of filtering assets.
 
-    Parse in user input of url and auth token and use them to
+    Parse in user input of url and credentials and use them to
     create an example archivist connection and passed-in properties
     attributes to filter all assets of the selected properties and
     attributes through function get_matching_assets.
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
 
     # list all assets with required attributes and properties

--- a/examples/filter_events.py
+++ b/examples/filter_events.py
@@ -1,10 +1,12 @@
 """Filter events of a archivist connection given url to Archivist and user Token.
 
-Main function parses in a url to the Archivist and a token, which is a user authorization.
+Main function parses in a url to the Archivist and credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.events.list() with appropriate properties and
+the credentials, called "arch", then call arch.events.list() with appropriate properties and
 attributes.
 """
+
+from os import getenv
 
 from archivist.archivist import Archivist
 
@@ -12,18 +14,26 @@ from archivist.archivist import Archivist
 def main():
     """Main function of filtering events.
 
-    Parse in user input of url and auth token and use them to
+    Parse in user input of url and credentials token and use them to
     create an example archivist connection and passed-in properties
     attributes to filter all events of the selected properties.
 
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
     # Get all events with required attributes and properties
     props = {"confirmation_status": "CONFIRMED"}

--- a/examples/get_asset.py
+++ b/examples/get_asset.py
@@ -1,12 +1,12 @@
 """Get an asset from a instance of Archivist
 
-Main parses in a a url, which is an instance of Archivist and a token, which
+Main parses in a a url, which is an instance of Archivist and credentials, which
 is a user authorization.
 
 The main function would then call arch.assets.read_by_signature() to get one asset from
 the instance.
 """
-
+from os import getenv
 
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistNotFoundError, ArchivistDuplicateError
@@ -15,16 +15,24 @@ from archivist.errors import ArchivistNotFoundError, ArchivistDuplicateError
 def main():
     """Main function of get_asset.
 
-    Parse in user input of url and auth token and use them to
+    Parse in user input of url and credentials and use them to
     create an example archivist connection and fetch all assets.
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
     try:
         asset = arch.assets.read_by_signature(

--- a/examples/subject_create.py
+++ b/examples/subject_create.py
@@ -1,10 +1,11 @@
 """Create a IAM subject given url to Archivist and user Token.
 
 Main function parses in
-a url to the Archivist and a token, which is a user authorization.
+a url to the Archivist and credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.subjects.create() and the subject will be created.
+the credentials, called "arch", then call arch.subjects.create() and the subject will be created.
 """
+from os import getenv
 
 from archivist.archivist import Archivist
 
@@ -12,17 +13,25 @@ from archivist.archivist import Archivist
 def main():
     """Main function of create subject.
 
-    Parse in user input of url and auth token and use them to
+    Parse in user input of url and credentials and use them to
     create an example archivist connection and create an asset.
 
     """
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
 
     subject = arch.subjects.create(

--- a/examples/subjects_filter.py
+++ b/examples/subjects_filter.py
@@ -1,24 +1,33 @@
 """Filter IAM subjects of a archivist connection given url to Archivist and user Token.
 
-Main function parses in a url to the Archivist and a token, which is a user authorization.
+Main function parses in a url to the Archivist and credentials, which is a user authorization.
 The main function would initialize an archivist connection using the url and
-the token, called "arch", then call arch.subjects.list() with suitable properties and
+credentials, called "arch", then call arch.subjects.list() with suitable properties and
 attributes.
 
 """
+from os import getenv
 
 from archivist.archivist import Archivist
 
 
 def main():
     """Main function of filtering subjects."""
-    with open(".auth_token", mode="r", encoding="utf-8") as tokenfile:
-        authtoken = tokenfile.read().strip()
+    # client id and client secret is obtained from the appidp endpoint - see the
+    # application registrations example code in examples/applications_registration.py
+    #
+    # client id is an environment variable. client_scret is stored in a file in a
+    # directory that has 0700 permissions. The location of this file is set in
+    # the client_secret_file environment variable.
+    client_id = getenv("ARCHIVIST_CLIENT_ID")
+    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
+        client_secret = tokenfile.read().strip()
 
     # Initialize connection to Archivist
     arch = Archivist(
         "https://app.rkvst.io",
-        authtoken,
+        (client_id, client_secret),
     )
 
     # count subjects...

--- a/functests/execsboms.py
+++ b/functests/execsboms.py
@@ -17,6 +17,16 @@ from archivist.timestamp import now_timestamp
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
+
+DISPLAY_NAME = "Application display name"
+CUSTOM_CLAIMS = {
+    "serial_number": "TL1000000101",
+    "has_cyclist_light": "true",
+}
+
+TEST_SBOM_PATH = "functests/test_resources/bom.xml"
+TEST_SBOM_DOWNLOAD_PATH = "functests/test_resources/downloaded_bom.xml"
+
 if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
     set_logger(environ["TEST_DEBUG"])
 
@@ -28,9 +38,6 @@ class TestSBOM(TestCase):
 
     maxDiff = None
 
-    TEST_SBOM_PATH = "functests/test_resources/bom.xml"
-    TEST_SBOM_DOWNLOAD_PATH = "functests/test_resources/downloaded_bom.xml"
-
     @classmethod
     def setUp(cls):
         with open(environ["TEST_AUTHTOKEN_FILENAME"], encoding="utf-8") as fd:
@@ -38,37 +45,38 @@ class TestSBOM(TestCase):
 
         cls.arch = Archivist(environ["TEST_ARCHIVIST"], auth, verify=False)
         cls.file_uuid: str = ""
+        cls.title = "TestSBOM"
 
         with suppress(FileNotFoundError):
-            remove(cls.TEST_SBOM_DOWNLOAD_PATH)
+            remove(TEST_SBOM_DOWNLOAD_PATH)
 
     @classmethod
     def tearDown(cls) -> None:
         """Remove the downloaded sbom for subsequent test runs"""
+        cls.arch = None
         with suppress(FileNotFoundError):
-            remove(cls.TEST_SBOM_DOWNLOAD_PATH)
+            remove(TEST_SBOM_DOWNLOAD_PATH)
 
     def test_sbom_upload_and_download(self):
         """
         Test sbom upload and download through the SDK
         """
+        print("Title:", self.title)
         now = now_timestamp()
-        with open(self.TEST_SBOM_PATH, "rb") as fd:
+        with open(TEST_SBOM_PATH, "rb") as fd:
             metadata = self.arch.sboms.upload(fd)
 
-        print("metadata", json_dumps(metadata.dict(), indent=4))
+        print("first upload", json_dumps(metadata.dict(), indent=4))
         identity = metadata.identity
-        with open(self.TEST_SBOM_DOWNLOAD_PATH, "wb") as fd:
+        with open(TEST_SBOM_DOWNLOAD_PATH, "wb") as fd:
             sbom = self.arch.sboms.download(identity, fd)
 
         print("sbom", sbom)
         clear_cache()
-        self.assertTrue(
-            cmp(self.TEST_SBOM_PATH, self.TEST_SBOM_DOWNLOAD_PATH, shallow=False)
-        )
+        self.assertTrue(cmp(TEST_SBOM_PATH, TEST_SBOM_DOWNLOAD_PATH, shallow=False))
 
         metadata1 = self.arch.sboms.read(identity)
-        print("metadata1", json_dumps(metadata1.dict(), indent=4))
+        print("read", json_dumps(metadata1.dict(), indent=4))
         self.assertEqual(
             metadata,
             metadata1,
@@ -91,25 +99,23 @@ class TestSBOM(TestCase):
             msg="Metadata not correct",
         )
 
-        sleep(1)  # otherwise test fails
-        metadata2 = self.arch.sboms.publish(identity)
-        print("metadata2", json_dumps(metadata2.dict(), indent=4))
+        metadata2 = self.arch.sboms.publish(identity, confirm=True)
+        print("publish", json_dumps(metadata2.dict(), indent=4))
         self.assertNotEqual(
             metadata1.published_date,
             metadata2.published_date,
             msg="Published_date not correct",
         )
-        metadata3 = self.arch.sboms.publish(identity)
-        print("metadata3", json_dumps(metadata3.dict(), indent=4))
+        metadata3 = self.arch.sboms.publish(identity, confirm=True)
+        print("publish again", json_dumps(metadata3.dict(), indent=4))
         self.assertEqual(
             metadata2.published_date,
             metadata3.published_date,
             msg="Published_date not correct",
         )
 
-        sleep(1)  # otherwise test fails
-        metadata4 = self.arch.sboms.withdraw(identity)
-        print("metadata4", json_dumps(metadata4.dict(), indent=4))
+        metadata4 = self.arch.sboms.withdraw(identity, confirm=True)
+        print("withdraw", json_dumps(metadata4.dict(), indent=4))
         self.assertNotEqual(
             metadata3.withdrawn_date,
             metadata4.withdrawn_date,
@@ -121,8 +127,8 @@ class TestSBOM(TestCase):
             msg="Published_date not correct",
         )
 
-        metadata5 = self.arch.sboms.withdraw(identity)
-        print("metadata5", json_dumps(metadata5.dict(), indent=4))
+        metadata5 = self.arch.sboms.withdraw(identity, confirm=True)
+        print("withdraw again", json_dumps(metadata5.dict(), indent=4))
         self.assertEqual(
             metadata4.withdrawn_date,
             metadata5.withdrawn_date,
@@ -141,3 +147,22 @@ class TestSBOM(TestCase):
         )
         for i, m in enumerate(metadatas):
             print(i, ":", json_dumps(m.dict(), indent=4))
+
+
+class TestSBOMWithApplication(TestSBOM):
+    """
+    Test Archivist SBOM upload/download
+    """
+
+    maxDiff = None
+
+    @classmethod
+    def setUp(cls):
+        super(TestSBOMWithApplication, cls).setUp()
+        cls.title = "TestSBOMWithApplication"
+        application = cls.arch.applications.create(
+            DISPLAY_NAME,
+            CUSTOM_CLAIMS,
+        )
+        auth = (application["client_id"], application["credentials"][0]["secret"])
+        cls.arch = Archivist(environ["TEST_ARCHIVIST"], auth, verify=False)

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -353,3 +353,35 @@ class TestArchivistPost(TestArchivistMethods):
                 "image/jpg",
                 msg="Incorrect mimetype",
             )
+
+
+class TestArchivistPostWithoutAuth(TestCase):
+    """
+    Test Archivist base method class
+    """
+
+    def setUp(self):
+        self.arch = Archivist("url", None)
+
+    def test_post_without_auth(self):
+        """
+        Test default post method
+        """
+        request = {"field1": "value1"}
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, request=request)
+            resp = self.arch.post("path/path", request)
+            self.assertEqual(
+                tuple(mock_post.call_args),
+                (
+                    (f"url/{ROOT}/path/path",),
+                    {
+                        "data": '{"field1": "value1"}',
+                        "headers": {
+                            "content-type": "application/json",
+                        },
+                        "verify": True,
+                    },
+                ),
+                msg="POST method called incorrectly",
+            )


### PR DESCRIPTION
Problem:
Common usage is now to use client credentials from an
application registration.

Solution:
Changed all example code to use client credentials.
Allow auth to be None in Archivist creation
Added functest that uses client credentials to publish SBOMS.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>