### PR TITLE
Upload SBOM with privacy and type

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -355,7 +355,13 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
 
     @retry_429
     def post_file(
-        self, path: str, fd: BinaryIO, mtype: str, *, form: Optional[str] = "file"
+        self,
+        path: str,
+        fd: BinaryIO,
+        mtype: str,
+        *,
+        form: Optional[str] = "file",
+        params: Optional[Dict] = None,
     ) -> Dict:
         """POST method (REST) - upload binary
 
@@ -365,6 +371,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
             path (str): e.g. v2/assets
             fd : iterable representing the contents of a file.
             mtype (str): mime type e.g. image/jpg
+            params (dict): dictiuonary of optional path params
 
         Returns:
             dict representing the response body (entity).
@@ -379,6 +386,10 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         headers = {
             "content-type": multipart.content_type,
         }
+        if params:
+            qry = "&".join(sorted(f"{k}={v}" for k, v in _dotstring(params)))
+            path = "?".join((path, qry))
+
         response = self._session.post(
             SEP.join((self.url, ROOT, path)),
             data=multipart,  # type: ignore    https://github.com/requests/toolbelt/issues/312

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -79,7 +79,7 @@ def _wait_for_confirmation(
     on_giveup=__on_giveup_confirmation,
 )
 def _wait_for_confirmation(self, identity):
-    """docstring"""
+    """Return None until entity is confirmed"""
     entity = self.read(identity)
 
     if CONFIRMATION_STATUS not in entity:
@@ -115,7 +115,7 @@ def __on_giveup_confirmed(details):
     on_giveup=__on_giveup_confirmed,
 )
 def _wait_for_confirmed(self, *, props=None, **kwargs) -> bool:
-    """docstring"""
+    """Return False until all entities are confirmed"""
 
     # look for unconfirmed entities
     newprops = deepcopy(props) if props else {}

--- a/archivist/withdrawer.py
+++ b/archivist/withdrawer.py
@@ -5,8 +5,6 @@
 
 import logging
 
-from typing import overload
-
 import backoff
 
 from .errors import ArchivistUnwithdrawnError
@@ -43,19 +41,6 @@ def __on_giveup_withdrawn(details):
     )
 
 
-# These overloads are used for type hinting, if self is sboms client then
-# an SBOM metadata will be returned.
-# Overloads are evaluated at startup but not at runtime, therefore
-# no test coverage be done directly.
-
-
-@overload
-def _wait_for_publication(
-    self: "sboms._SbomsClient", identity: str
-) -> "sbommetadata.SBOM":
-    ...  # pragma: no cover
-
-
 @backoff.on_predicate(
     backoff.expo,
     logger=LOGGER,
@@ -64,7 +49,7 @@ def _wait_for_publication(
     on_giveup=__on_giveup_withdrawn,
 )
 def _wait_for_withdrawn(self, identity):
-    """docstring"""
+    """Return None until withdrawn date is set"""
     entity = self.read(identity)
 
     if entity.withdrawn_date:

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -174,7 +174,9 @@ class TestApplications(TestCase):
     def test_archivist_token(self):
         """
         Test archivist with client id/secret
+        WARN: this test takes over 10 minutes
         """
+        print("This test takes over 10 minutes...")
         application = self.arch.applications.create(
             self.display_name,
             CUSTOM_CLAIMS,
@@ -187,6 +189,7 @@ class TestApplications(TestCase):
         )
 
         # archivist using app registration
+        print("New Arch")
         new_arch = Archivist(
             environ["TEST_ARCHIVIST"],
             (application["client_id"], application["credentials"][0]["secret"]),
@@ -198,6 +201,9 @@ class TestApplications(TestCase):
         traffic_light = deepcopy(ATTRS)
         traffic_light["arc_display_type"] = "Traffic light with violation camera"
         asset = new_arch.assets.create(
+            props={
+                "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
+            },
             attrs=traffic_light,
             confirm=True,
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 # code quality
 autopep8~=1.5
 black~=21.4b2
-coverage~=5.4
+coverage~=6.2
 pip-audit~=1.0.0
 pycodestyle~=2.6
 pylint~=2.6

--- a/scripts/unittests.sh
+++ b/scripts/unittests.sh
@@ -26,7 +26,6 @@ rm -rf htmlcov
 COVERAGE="coverage"
 ${COVERAGE} --version
 ${COVERAGE} run --branch --source archivist -m unittest -v 
-${COVERAGE} annotate
 ${COVERAGE} html
 ${COVERAGE} xml
 ${COVERAGE} report

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -226,6 +226,70 @@ class TestArchivistPost(TestArchivistMethods):
                 msg="Incorrect mimetype",
             )
 
+    def test_post_file_with_params(self):
+        """
+        Test default post_file method
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200)
+            resp = self.arch.post_file(
+                "path/path",
+                BytesIO(b"lotsofbytes"),
+                "image/jpg",
+                params={"field1": "value1", "field2": "value2"},
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                len(args),
+                1,
+                msg="Incorrect number of arguments",
+            )
+            self.assertEqual(
+                args[0],
+                f"url/{ROOT}/path/path?field1=value1&field2=value2",
+                msg="Incorrect first argument",
+            )
+            self.assertEqual(
+                len(kwargs),
+                3,
+                msg="Incorrect number of keyword arguments",
+            )
+            headers = kwargs.get("headers")
+            self.assertNotEqual(
+                headers,
+                None,
+                msg="Header does not exist",
+            )
+            self.assertTrue(
+                headers["content-type"].startswith("multipart/form-data"),
+                msg="Incorrect content-type",
+            )
+            data = kwargs.get("data")
+            self.assertIsNotNone(
+                data,
+                msg="Incorrect data",
+            )
+            fields = data.fields
+            self.assertIsNotNone(
+                fields,
+                msg="Incorrect fields",
+            )
+            myfile = fields.get("file")
+            self.assertIsNotNone(
+                myfile,
+                msg="Incorrect file key",
+            )
+            self.assertEqual(
+                myfile[0],
+                "filename",
+                msg="Incorrect filename",
+            )
+            self.assertEqual(
+                myfile[2],
+                "image/jpg",
+                msg="Incorrect mimetype",
+            )
+
     def test_post_file_with_error(self):
         """
         Test post method with error


### PR DESCRIPTION
Problem:
Uploading an sbom can specify the type and the privacy setting.

Solution:
Added params optional argument that specifies a dict of "sbom_type"
and "privacy".
Additionally added confim=True option to upload method to ensure that
the metadata is written to the database before return.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>