### PR TITLE
Generated docs using latest Sphinx

### DIFF
--- a/docs/access_policies_filter.rst
+++ b/docs/access_policies_filter.rst
@@ -1,4 +1,4 @@
-.. _access_policies_filter:
+.. _access_policies_filterref:
 
 Filter IAM access_policies
 ...........................

--- a/docs/access_policy_create.rst
+++ b/docs/access_policy_create.rst
@@ -1,4 +1,4 @@
-.. _access_policy_create:
+.. _access_policy_createref:
 
 Create IAM access_policy
 ........................

--- a/docs/applications_registration.rst
+++ b/docs/applications_registration.rst
@@ -1,4 +1,4 @@
-.. _applications_registration:
+.. _applications_registrationref:
 
 Create IAM Application Registration and Tokens
 ...............................................

--- a/docs/archivist.rst
+++ b/docs/archivist.rst
@@ -1,8 +1,8 @@
 
-.. _archivist:
+.. _archivistref:
 
-Archivist
-----------
+Archivist Class
+----------------
 
 
 .. automodule:: archivist.archivist

--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -1,8 +1,8 @@
 
-.. _assets:
+.. _assetsref:
 
-Assets
-----------
+Assets Class
+------------
 
 
 .. automodule:: archivist.assets

--- a/docs/attachments.rst
+++ b/docs/attachments.rst
@@ -1,8 +1,8 @@
 
-.. _attachments:
+.. _attachmentsref:
 
-Attachments
-------------
+Attachments Class
+------------------
 
 
 .. automodule:: archivist.attachments

--- a/docs/compliance_policies/compliance.rst
+++ b/docs/compliance_policies/compliance.rst
@@ -1,5 +1,5 @@
 
-.. _compliance:
+.. _complianceref:
 
 Compliance
 --------------------

--- a/docs/compliance_policies/compliance_policies.rst
+++ b/docs/compliance_policies/compliance_policies.rst
@@ -1,8 +1,8 @@
 
-.. _compliance_policies_client:
+.. _compliance_policies_clientref:
 
-Compliance Policies
---------------------
+Compliance Policies Client
+--------------------------
 
 
 .. automodule:: archivist.compliance_policies

--- a/docs/compliance_policies/index.rst
+++ b/docs/compliance_policies/index.rst
@@ -1,4 +1,4 @@
-.. _compliance_policies:
+.. _compliance_policiesindex:
 
 Compliance Policies
 ===================

--- a/docs/compliance_policies_demo.rst
+++ b/docs/compliance_policies_demo.rst
@@ -1,4 +1,4 @@
-.. _compliance_policies_demo:
+.. _compliance_policies_demoref:
 
 Compliance Policies Demo
 ...........................
@@ -8,8 +8,8 @@ a Compliance Policy workflow.
 
 Reference yaml files are available here:
 
-    - :ref:`compliance_policies_demo_dynamic_tolerance`
-    - :ref:`compliance_policies_demo_richness`
+    - :ref:`compliance_policies_demo_dynamic_toleranceref`
+    - :ref:`compliance_policies_demo_richnessref`
 
 To invoke this command:
 

--- a/docs/compliance_policies_demo_dynamic_tolerance.rst
+++ b/docs/compliance_policies_demo_dynamic_tolerance.rst
@@ -1,9 +1,9 @@
-.. _compliance_policies_demo_dynamic_tolerance:
+.. _compliance_policies_demo_dynamic_toleranceref:
 
 Compliance Policies Dynamic Tolerance Demo
 ...........................................
 
-Code to use this file is found here :ref:`compliance_policies_demo`
+Code to use this file is found here :ref:`compliance_policies_demoref`
 
 
 .. literalinclude:: ../examples/compliance_stories/dynamic_tolerance_story.yaml

--- a/docs/compliance_policies_demo_richness.rst
+++ b/docs/compliance_policies_demo_richness.rst
@@ -1,9 +1,9 @@
-.. _compliance_policies_demo_richness:
+.. _compliance_policies_demo_richnessref:
 
 Compliance Policies Richness Demo
 ..................................
 
-Code to use this file is found here :ref:`compliance_policies_demo`
+Code to use this file is found here :ref:`compliance_policies_demoref`
 
 .. literalinclude:: ../examples/compliance_stories/richness_story.yaml
    :language: yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,10 +14,10 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
+import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 from archivist import about
-import sphinx_rtd_theme
 project = 'Jitsuin Archivist'
 copyright = '2021, support@jitsuin.com'
 author = 'support@jitsuin.com'
@@ -25,8 +25,6 @@ author = 'support@jitsuin.com'
 version = about.__version__
 release = about.__version__
 
-
-autodoc_member_order = 'bysource'
 
 # -- General configuration ---------------------------------------------------
 
@@ -37,7 +35,6 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
-    "sphinx.ext.autosummary",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",

--- a/docs/create_asset.rst
+++ b/docs/create_asset.rst
@@ -1,7 +1,7 @@
-.. _create_asset:
+.. _create_assetref:
 
-Create Asset
-............
+Create Asset Eaxmple
+.....................
 
 .. literalinclude:: ../examples/create_asset.py
    :language: python

--- a/docs/create_event.rst
+++ b/docs/create_event.rst
@@ -1,7 +1,7 @@
-.. _create_event:
+.. _create_eventref:
 
-Create Event
-............
+Create Event Example
+.....................
 
 .. literalinclude:: ../examples/create_event.py
    :language: python

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,8 +1,8 @@
 
-.. _errors:
+.. _errorsref:
 
-Errors
-----------
+Errors Parsing
+--------------
 
 
 .. automodule:: archivist.errors

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,8 +1,8 @@
 
-.. _events:
+.. _eventsref:
 
-Events
-----------
+Events Class
+-------------
 
 
 .. automodule:: archivist.events

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1,4 +1,4 @@
-.. _features:
+.. _featuresref:
 
 Features
 =============================================
@@ -11,7 +11,7 @@ The definitive guide to the REST API is defined here: https://docs.rkvst.com
 This python SDK offers a number of advantages over a simple 
 REST api (in any language):
 
-    *  versioned package for the python 3.6,3.7,3.8,3.9 ecosystem.
+    *  versioned package for the python 3.6,3.7,3.8,3.9,3.10 ecosystem.
     *  automatic confirmation of assets and events: just set **confirm=True** when
        creating the asset or event and a sophisticated retry and exponential backoff
        algorithm will take care of everything.

--- a/docs/filter_assets.rst
+++ b/docs/filter_assets.rst
@@ -1,4 +1,4 @@
-.. _filter_assets:
+.. _filter_assetsref:
 
 Filter Assets
 .............

--- a/docs/filter_events.rst
+++ b/docs/filter_events.rst
@@ -1,4 +1,4 @@
-.. _filter_events:
+.. _filter_eventsref:
 
 Filter Events
 .............

--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -1,6 +1,6 @@
-.. _fixtures:
+.. _fixturesref:
 
-Fixtures
+Fixtures (Common Attributes)
 =============================================
 
 One can specify common attributes when creating/counting/querying assets, events

--- a/docs/get_asset.rst
+++ b/docs/get_asset.rst
@@ -1,7 +1,7 @@
-.. _get_asset:
+.. _get_assetref:
 
-Get Asset
-.........
+Get Asset Example
+..................
 
 .. literalinclude:: ../examples/get_asset.py
    :language: python

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,4 +1,4 @@
-.. _getting_started:
+.. _getting_startedref:
 
 Getting started
 ===============

--- a/docs/iam/index.rst
+++ b/docs/iam/index.rst
@@ -1,4 +1,4 @@
-.. _iam:
+.. _iamindex:
 
 Identity and Access Management (IAM)
 ====================================

--- a/docs/locations.rst
+++ b/docs/locations.rst
@@ -1,8 +1,8 @@
 
-.. _locations:
+.. _locationsref:
 
-Locations
-----------
+Locations Class
+----------------
 
 
 .. automodule:: archivist.locations

--- a/docs/proof_mechanism.rst
+++ b/docs/proof_mechanism.rst
@@ -1,8 +1,8 @@
 
-.. _proof_mechanism:
+.. _proof_mechanismref:
 
-Proof Mechanism
----------------
+Proof Mechanism Enumeration
+----------------------------
 
 
 .. automodule:: archivist.proof_mechanism

--- a/docs/sboms/index.rst
+++ b/docs/sboms/index.rst
@@ -1,4 +1,4 @@
-.. _sboms:
+.. _sbomsindex:
 
 Software Bill of Materials (SBOM)
 =================================

--- a/docs/sboms/sboms.rst
+++ b/docs/sboms/sboms.rst
@@ -1,7 +1,7 @@
 
-.. _sboms:
+.. _sbomsref:
 
-SBOMS
+SBOMS Class
 ------------
 
 

--- a/docs/subject_create.rst
+++ b/docs/subject_create.rst
@@ -1,7 +1,7 @@
-.. _subject_create:
+.. _subject_createref:
 
-Create IAM subject
-..................
+Create IAM subject Example
+...........................
 
 .. literalinclude:: ../examples/subject_create.py
    :language: python

--- a/docs/subjects_filter.rst
+++ b/docs/subjects_filter.rst
@@ -1,7 +1,7 @@
-.. _subjects_filter:
+.. _subjects_filterref:
 
-Filter IAM subjects
-....................
+Filter IAM subjects Example
+...........................
 
 .. literalinclude:: ../examples/subjects_filter.py
    :language: python

--- a/docs/timestamp.rst
+++ b/docs/timestamp.rst
@@ -1,8 +1,8 @@
 
-.. _timestamp:
+.. _timestampref:
 
-Timestamp
-----------
+Timestamp Definition
+--------------------
 
 
 .. automodule:: archivist.timestamp

--- a/examples/access_policies_filter.py
+++ b/examples/access_policies_filter.py
@@ -18,7 +18,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/access_policy_create.py
+++ b/examples/access_policy_create.py
@@ -22,7 +22,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -77,7 +77,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -111,7 +111,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/filter_assets.py
+++ b/examples/filter_assets.py
@@ -23,7 +23,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/filter_events.py
+++ b/examples/filter_events.py
@@ -22,7 +22,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/get_asset.py
+++ b/examples/get_asset.py
@@ -21,7 +21,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/subject_create.py
+++ b/examples/subject_create.py
@@ -20,7 +20,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/examples/subjects_filter.py
+++ b/examples/subjects_filter.py
@@ -16,7 +16,7 @@ def main():
     # client id and client secret is obtained from the appidp endpoint - see the
     # application registrations example code in examples/applications_registration.py
     #
-    # client id is an environment variable. client_scret is stored in a file in a
+    # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     client_id = getenv("ARCHIVIST_CLIENT_ID")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,8 @@ pylint~=2.6
 twine~=3.4
 
 # documentation
-sphinx~=3.5
-sphinx-rtd-theme~=0.5.2
+sphinx~=4.3
+sphinx-rtd-theme~=1.0.0
 
 # examples
 pyyaml~=5.1.2


### PR DESCRIPTION
Problem:
Upgrading to sphinx 4.3.1 produces 'unable to import' and
duplicate label errors.

Solution:
Removed autosummary option and renamed labels to be unique.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>