### PR TITLE
SBOMS missing rkvst_link field

### DIFF
--- a/archivist/compliance_policy_requests.py
+++ b/archivist/compliance_policy_requests.py
@@ -10,7 +10,7 @@ from typing import List
 from .compliance_policy_type import CompliancePolicyType
 from .or_dict import and_list
 
-# NB: the oder of the fields is important. Fields with default values must
+# NB: the order of the fields is important. Fields with default values must
 #    appear after fields without. This is why the compliance_type is last
 #    in every case.
 

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -10,7 +10,7 @@ from enum import Enum
 import logging
 from sys import exit as sys_exit
 
-from . import archivist
+from .archivist import Archivist
 from .logger import set_logger
 from .proof_mechanism import ProofMechanism
 
@@ -78,9 +78,7 @@ def common_parser(description):
         default=ProofMechanism.SIMPLE_HASH,
         help="mechanism for proving the evidence for events on the Asset",
     )
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
+    parser.add_argument(
         "-t",
         "--auth-token",
         type=str,
@@ -91,7 +89,7 @@ def common_parser(description):
         help="FILE containing API authentication token",
     )
 
-    return parser, security
+    return parser
 
 
 def endpoint(args):
@@ -113,7 +111,7 @@ def endpoint(args):
         with open(args.auth_token_file, mode="r", encoding="utf-8") as tokenfile:
             authtoken = tokenfile.read().strip()
 
-        arch = archivist.Archivist(args.url, authtoken, verify=False, fixtures=fixtures)
+        arch = Archivist(args.url, authtoken, verify=False, fixtures=fixtures)
 
     if arch is None:
         LOGGER.error("Critical error.  Aborting.")

--- a/archivist/sbommetadata.py
+++ b/archivist/sbommetadata.py
@@ -34,6 +34,7 @@ class SBOM:
     lifecycle_status: str
     withdrawn_date: str
     published_date: str
+    rkvst_link: str = ""
 
     def dict(self):
         """Emit dictionary representation"""

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -47,6 +47,7 @@ PROPS = {
     "lifecycle_status": "Active",
     "published_date": "",
     "withdrawn_date": "",
+    "rkvst_link": "",
 }
 PUBLISHED_PROPS = {**PROPS, **{"published_date": "2021-11-11T17:02:06Z"}}
 WITHDRAWN_PROPS = {**PROPS, **{"withdrawn_date": "2021-11-11T17:02:06Z"}}


### PR DESCRIPTION
Problem:
SBOMS failure because of new rkvst_link attribute

Solution:
Add rkvst_link to SBOMmetadata dataclass

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>