### PR TITLE
Allow downloading bad attachments

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -39,8 +39,6 @@ from .dictmerge import _deepmerge
 
 from .assets import Asset
 
-FIXTURE_LABEL = "access_policies"
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -185,7 +183,7 @@ class _AccessPoliciesClient:
         if access_permissions is not None:
             query["access_permissions"] = access_permissions
 
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(ACCESS_POLICIES_LABEL), query)
 
     def count(self, *, display_name: Optional[str] = None) -> int:
         """Count access policies.

--- a/archivist/applications.py
+++ b/archivist/applications.py
@@ -35,8 +35,6 @@ from .constants import (
 )
 from .dictmerge import _deepmerge
 
-FIXTURE_LABEL = "applications"
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -182,7 +180,7 @@ class _ApplicationsClient:
         if custom_claims is not None:
             query["custom_claims"] = custom_claims
 
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(APPLICATIONS_LABEL), query)
 
     def list(
         self,

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -275,6 +275,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         fd: BinaryIO,
         *,
         headers: Optional[Dict] = None,
+        query: Optional[Dict] = None,
     ) -> Response:
         """GET method (REST) - chunked
 
@@ -286,11 +287,16 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
             fd (file): an iterable representing a file (usually from open())
                 the file must be opened in binary mode
             headers (dict): optional REST headers
+            query (dict): optional query strings
 
         Returns:
             REST response (not the response body)
 
         """
+        qry = self.__query(query)
+        if qry:
+            identity = "?".join((identity, qry))
+
         response = self._session.get(
             SEP.join((self.url, ROOT, subpath, identity)),
             headers=self.__add_headers(headers),

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -98,9 +98,6 @@ class Asset(dict):
         return None
 
 
-FIXTURE_LABEL = "assets"
-
-
 class _AssetsClient:
     """AssetsClient
 
@@ -205,7 +202,7 @@ class _AssetsClient:
         if attrs:
             query["attributes"] = attrs
 
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(ASSETS_LABEL), query)
 
     def count(
         self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None

--- a/archivist/compliance_policies.py
+++ b/archivist/compliance_policies.py
@@ -47,8 +47,6 @@ from .constants import (
 )
 from .dictmerge import _deepmerge
 
-FIXTURE_LABEL = "compliance_policies"
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -172,7 +170,9 @@ class _CompliancePoliciesClient:
     def __query(self, props: Optional[Dict]) -> Dict:
         query = deepcopy(props) if props else {}
         # pylint: disable=protected-access
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(
+            self._archivist.fixtures.get(COMPLIANCE_POLICIES_LABEL), query
+        )
 
     def count(self, *, props: Optional[Dict] = None) -> int:
         """Count compliance policies.

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -42,8 +42,6 @@ from .dictmerge import _deepmerge
 from .errors import ArchivistNotFoundError
 
 
-FIXTURE_LABEL = "events"
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -221,7 +219,7 @@ class _EventsClient:
         if asset_attrs:
             query["asset_attributes"] = asset_attrs
 
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(EVENTS_LABEL), query)
 
     def count(
         self,

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -33,9 +33,6 @@ from .constants import LOCATIONS_SUBPATH, LOCATIONS_LABEL
 from .dictmerge import _deepmerge
 
 
-FIXTURE_LABEL = "locations"
-
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -124,7 +121,7 @@ class _LocationsClient:
         if attrs:
             query["attributes"] = attrs
 
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(LOCATIONS_LABEL), query)
 
     def count(
         self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None

--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -49,8 +49,6 @@ from .sbommetadata import SBOM
 
 LOGGER = logging.getLogger(__name__)
 
-FIXTURE_LABEL = "sboms"
-
 
 class _SBOMSClient:
     """SBOMSClient
@@ -167,7 +165,7 @@ class _SBOMSClient:
 
     def __query(self, metadata: Optional[Dict]) -> Dict:
         query = deepcopy(metadata) if metadata else {}
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(SBOMS_LABEL), query)
 
     def list(
         self,

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -34,8 +34,6 @@ from .constants import (
 )
 from .dictmerge import _deepmerge
 
-FIXTURE_LABEL = "subjects"
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -192,7 +190,7 @@ class _SubjectsClient:
         if tessera_pub_keys is not None:
             query["tessera_pub_key"] = tessera_pub_keys
 
-        return _deepmerge(self._archivist.fixtures.get(FIXTURE_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(SUBJECTS_LABEL), query)
 
     def count(self, *, display_name: Optional[str] = None) -> int:
         """Count subjects.

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -8,7 +8,10 @@ from contextlib import suppress
 from filecmp import clear_cache, cmp
 
 from archivist.archivist import Archivist
+from archivist.logger import set_logger
 
+if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
+    set_logger(environ["TEST_DEBUG"])
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -50,6 +53,46 @@ class TestAttachmentstCreate(TestCase):
 
         with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
             attachment = self.arch.attachments.download(file_uuid, fd)
+
+        # Check the downloaded file is identical to the one that was uploaded
+        clear_cache()
+        self.assertTrue(
+            cmp(self.TEST_IMAGE_PATH, self.TEST_IMAGE_DOWNLOAD_PATH, shallow=False)
+        )
+
+    def test_attachment_upload_and_download_allow_insecure(self):
+        """
+        Test file upload through the SDK
+        Test file download through the SDK
+        """
+        with open(self.TEST_IMAGE_PATH, "rb") as fd:
+            attachment = self.arch.attachments.upload(fd)
+            file_uuid = attachment["identity"]
+
+        with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
+            attachment = self.arch.attachments.download(
+                file_uuid, fd, query={"allow_insecure": True}
+            )
+
+        # Check the downloaded file is identical to the one that was uploaded
+        clear_cache()
+        self.assertTrue(
+            cmp(self.TEST_IMAGE_PATH, self.TEST_IMAGE_DOWNLOAD_PATH, shallow=False)
+        )
+
+    def test_attachment_upload_and_download_allow_not_scanned(self):
+        """
+        Test file upload through the SDK
+        Test file download through the SDK
+        """
+        with open(self.TEST_IMAGE_PATH, "rb") as fd:
+            attachment = self.arch.attachments.upload(fd)
+            file_uuid = attachment["identity"]
+
+        with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
+            attachment = self.arch.attachments.download(
+                file_uuid, fd, query={"allow_not_scanned": True}
+            )
 
         # Check the downloaded file is identical to the one that was uploaded
         clear_cache()


### PR DESCRIPTION
Problem:
An attachment that is not virus scanned or has a detected virus
is normally not allowed to be downloaded.

Solution:
Add optional query params to the download method in the
AssetsClient class that allows downloading bad attachment.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>