### PR TITLE
Attachments selectors changed

### DIFF
--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -110,7 +110,7 @@ class _AttachmentsClient:
         Args:
             identity (str): attachment identity e.g. attachments/xxxxxxxxxxxxxxxxxxxxxxx
             fd (file): opened file escriptor or other file-type sink..
-            query (dict): e.g. {"allow_insecure": True} OR {"allow_not_scanned": True }
+            query (dict): e.g. {"allow_insecure": "true"} OR {"strict": "true" }
 
         Returns:
             REST response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 backoff~=1.11
 certifi
-flatten-dict~=0.3.0
-iso8601~=0.1.13
+flatten-dict~=0.3
+iso8601~=0.1
 requests~=2.22
 requests-toolbelt~=0.9
 rfc3339~=6.2

--- a/unittests/testattachments.py
+++ b/unittests/testattachments.py
@@ -165,8 +165,8 @@ class TestAttachments(TestCase):
 
     def test_attachments_download_with_query(self):
         """
-        Test attachment download - usually both allow options are
-        not required.
+        Test attachment download - usually both allow_insecure and
+        strict are not required at the same time.
         """
 
         with mock.patch.object(self.arch._session, "get") as mock_get:
@@ -195,14 +195,14 @@ class TestAttachments(TestCase):
                 attachment = self.arch.attachments.download(
                     IDENTITY,
                     fd,
-                    query={"allow_insecure": True, "allow_not_scanned": True},
+                    query={"allow_insecure": "true", "strict": "true"},
                 )
                 args, kwargs = mock_get.call_args
                 self.assertEqual(
                     args,
                     (
                         f"url/{ROOT}/{ATTACHMENTS_SUBPATH}/{IDENTITY}"
-                        "?allow_insecure=True&allow_not_scanned=True",
+                        "?allow_insecure=true&strict=true",
                     ),
                     msg="DOWNLOAD method called incorrectly",
                 )


### PR DESCRIPTION
Problem:
Attachments: Allow_not_scanned has been replaced with 'strict' with
reversed meaning.

Solution:
Changed allow_not_scanned with strict selector.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>