### PR TITLE
New requests library with better api

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -87,7 +87,9 @@ class _AccessPoliciesClient:
         """
         LOGGER.debug("Create Access Policy %s", props)
         return self.create_from_data(
-            self.__query(props, filters=filters, access_permissions=access_permissions),
+            self.__params(
+                props, filters=filters, access_permissions=access_permissions
+            ),
         )
 
     def create_from_data(self, data: Dict) -> AccessPolicy:
@@ -154,7 +156,7 @@ class _AccessPoliciesClient:
             **self._archivist.patch(
                 ACCESS_POLICIES_SUBPATH,
                 identity,
-                self.__query(
+                self.__params(
                     props, filters=filters, access_permissions=access_permissions
                 ),
             )
@@ -174,21 +176,21 @@ class _AccessPoliciesClient:
         """
         return self._archivist.delete(ACCESS_POLICIES_SUBPATH, identity)
 
-    def __query(
+    def __params(
         self,
         props: Optional[Dict],
         *,
         filters: Optional[List] = None,
         access_permissions: Optional[List] = None,
     ) -> Dict:
-        query = deepcopy(props) if props else {}
+        params = deepcopy(props) if props else {}
         if filters is not None:
-            query["filters"] = filters
+            params["filters"] = filters
 
         if access_permissions is not None:
-            query["access_permissions"] = access_permissions
+            params["access_permissions"] = access_permissions
 
-        return _deepmerge(self._archivist.fixtures.get(ACCESS_POLICIES_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(ACCESS_POLICIES_LABEL), params)
 
     def count(self, *, display_name: Optional[str] = None) -> int:
         """Count access policies.
@@ -202,10 +204,10 @@ class _AccessPoliciesClient:
             integer count of access policies.
 
         """
-        query = {"display_name": display_name} if display_name is not None else None
+        params = {"display_name": display_name} if display_name is not None else None
         return self._archivist.count(
             f"{ACCESS_POLICIES_SUBPATH}/{ACCESS_POLICIES_LABEL}",
-            query=query,
+            params=params,
         )
 
     def list(
@@ -223,14 +225,14 @@ class _AccessPoliciesClient:
             iterable that returns :class:`AccessPolicy` instances
 
         """
-        query = {"display_name": display_name} if display_name is not None else None
+        params = {"display_name": display_name} if display_name is not None else None
         return (
             AccessPolicy(**a)
             for a in self._archivist.list(
                 f"{ACCESS_POLICIES_SUBPATH}/{ACCESS_POLICIES_LABEL}",
                 ACCESS_POLICIES_LABEL,
                 page_size=page_size,
-                query=query,
+                params=params,
             )
         )
 

--- a/archivist/appidp.py
+++ b/archivist/appidp.py
@@ -79,6 +79,6 @@ class _AppIDPClient:
                     "client_id": client_id,
                     "client_secret": client_secret,
                 },
-                noheaders=True,
+                data=True,
             )
         )

--- a/archivist/applications.py
+++ b/archivist/applications.py
@@ -75,7 +75,7 @@ class _ApplicationsClient:
         """
         LOGGER.debug("Create Application %s", display_name)
         return self.create_from_data(
-            self.__query(
+            self.__params(
                 display_name=display_name,
                 custom_claims=custom_claims,
             ),
@@ -144,7 +144,7 @@ class _ApplicationsClient:
             **self._archivist.patch(
                 APPLICATIONS_SUBPATH,
                 identity,
-                self.__query(
+                self.__params(
                     display_name=display_name,
                     custom_claims=custom_claims,
                 ),
@@ -165,22 +165,22 @@ class _ApplicationsClient:
         """
         return self._archivist.delete(APPLICATIONS_SUBPATH, identity)
 
-    def __query(
+    def __params(
         self,
         *,
         display_name: Optional[str] = None,
         custom_claims: Optional[Dict] = None,
     ) -> Dict:
 
-        query = {}
+        params = {}
 
         if display_name is not None:
-            query["display_name"] = display_name
+            params["display_name"] = display_name
 
         if custom_claims is not None:
-            query["custom_claims"] = custom_claims
+            params["custom_claims"] = custom_claims
 
-        return _deepmerge(self._archivist.fixtures.get(APPLICATIONS_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(APPLICATIONS_LABEL), params)
 
     def list(
         self,
@@ -206,7 +206,7 @@ class _ApplicationsClient:
                 f"{APPLICATIONS_SUBPATH}/{APPLICATIONS_LABEL}",
                 APPLICATIONS_LABEL,
                 page_size=page_size,
-                query=self.__query(display_name=display_name),
+                params=self.__params(display_name=display_name),
             )
         )
 

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -137,7 +137,7 @@ class _AssetsClient:
         # default behaviours  are added first - any set in user-specified fixtures or
         # in the method args will overide...
         newprops = _deepmerge({"behaviours": BEHAVIOURS}, props)
-        data = self.__query(newprops, attrs)
+        data = self.__params(newprops, attrs)
         return self.create_from_data(data, confirm=confirm)
 
     def create_from_data(self, data: Dict, *, confirm: bool = False) -> Asset:
@@ -195,12 +195,12 @@ class _AssetsClient:
         """
         return Asset(**self._archivist.get(ASSETS_SUBPATH, identity))
 
-    def __query(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
-        query = deepcopy(props) if props else {}
+    def __params(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
+        params = deepcopy(props) if props else {}
         if attrs:
-            query["attributes"] = attrs
+            params["attributes"] = attrs
 
-        return _deepmerge(self._archivist.fixtures.get(ASSETS_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(ASSETS_LABEL), params)
 
     def count(
         self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
@@ -218,7 +218,7 @@ class _AssetsClient:
 
         """
         return self._archivist.count(
-            f"{ASSETS_SUBPATH}/{ASSETS_LABEL}", query=self.__query(props, attrs)
+            f"{ASSETS_SUBPATH}/{ASSETS_LABEL}", params=self.__params(props, attrs)
         )
 
     def wait_for_confirmed(
@@ -275,7 +275,7 @@ class _AssetsClient:
                 f"{ASSETS_SUBPATH}/{ASSETS_LABEL}",
                 ASSETS_LABEL,
                 page_size=page_size,
-                query=self.__query(props, attrs),
+                params=self.__params(props, attrs),
             )
         )
 
@@ -298,6 +298,6 @@ class _AssetsClient:
             **self._archivist.get_by_signature(
                 f"{ASSETS_SUBPATH}/{ASSETS_LABEL}",
                 ASSETS_LABEL,
-                query=self.__query(props, attrs),
+                params=self.__params(props, attrs),
             )
         )

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -89,17 +89,17 @@ class _AttachmentsClient:
             )
         )
 
-    def __query(self, params: Optional[Dict]) -> Dict:
-        query = deepcopy(params) if params else {}
+    def __params(self, params: Optional[Dict]) -> Dict:
+        params = deepcopy(params) if params else {}
         # pylint: disable=protected-access
-        return _deepmerge(self._archivist.fixtures.get(ATTACHMENTS_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(ATTACHMENTS_LABEL), params)
 
     def download(
         self,
         identity: str,
         fd: BinaryIO,
         *,
-        query: Optional[Dict] = None,
+        params: Optional[Dict] = None,
     ) -> Response:
         """Read attachment
 
@@ -110,7 +110,7 @@ class _AttachmentsClient:
         Args:
             identity (str): attachment identity e.g. attachments/xxxxxxxxxxxxxxxxxxxxxxx
             fd (file): opened file escriptor or other file-type sink..
-            query (dict): e.g. {"allow_insecure": "true"} OR {"strict": "true" }
+            params (dict): e.g. {"allow_insecure": "true"} OR {"strict": "true" }
 
         Returns:
             REST response
@@ -120,5 +120,5 @@ class _AttachmentsClient:
             ATTACHMENTS_SUBPATH,
             identity,
             fd,
-            query=self.__query(query),
+            params=self.__params(params),
         )

--- a/archivist/compliance_policies.py
+++ b/archivist/compliance_policies.py
@@ -160,11 +160,11 @@ class _CompliancePoliciesClient:
         """
         return self._archivist.delete(COMPLIANCE_POLICIES_SUBPATH, identity)
 
-    def __query(self, props: Optional[Dict]) -> Dict:
-        query = deepcopy(props) if props else {}
+    def __params(self, props: Optional[Dict]) -> Dict:
+        params = deepcopy(props) if props else {}
         # pylint: disable=protected-access
         return _deepmerge(
-            self._archivist.fixtures.get(COMPLIANCE_POLICIES_LABEL), query
+            self._archivist.fixtures.get(COMPLIANCE_POLICIES_LABEL), params
         )
 
     def count(self, *, props: Optional[Dict] = None) -> int:
@@ -181,7 +181,7 @@ class _CompliancePoliciesClient:
         """
         return self._archivist.count(
             f"{COMPLIANCE_POLICIES_SUBPATH}/{COMPLIANCE_POLICIES_LABEL}",
-            query=self.__query(props),
+            params=self.__params(props),
         )
 
     def list(self, *, page_size: Optional[int] = None, props: Dict = None):
@@ -203,7 +203,7 @@ class _CompliancePoliciesClient:
                 f"{COMPLIANCE_POLICIES_SUBPATH}/{COMPLIANCE_POLICIES_LABEL}",
                 COMPLIANCE_POLICIES_LABEL,
                 page_size=page_size,
-                query=self.__query(props),
+                params=self.__params(props),
             )
         )
 
@@ -223,6 +223,6 @@ class _CompliancePoliciesClient:
             **self._archivist.get_by_signature(
                 f"{COMPLIANCE_POLICIES_SUBPATH}/{COMPLIANCE_POLICIES_LABEL}",
                 COMPLIANCE_POLICIES_LABEL,
-                query=self.__query(props),
+                params=self.__params(props),
             )
         )

--- a/archivist/dictmerge.py
+++ b/archivist/dictmerge.py
@@ -23,6 +23,8 @@ def _deepmerge(dct1: Optional[dict], dct2: Optional[dict]) -> dict:
     return unflatten({**flatten(dct1), **flatten(dct2)})
 
 
-def _dotstring(dct: dict):
-    """Emit nested dictionary as dot delimited string"""
-    return flatten(dct, reducer="dot").items()
+def _dotdict(dct: dict) -> dict:
+    """Emit nested dictionary as dot delimited dict with one level"""
+    if dct is None:
+        return None
+    return flatten(dct, reducer="dot")

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -145,7 +145,7 @@ class _EventsClient:
         LOGGER.debug("Create Event %s/%s", asset_id, props)
         return self.create_from_data(
             asset_id,
-            self.__query(props, attrs, asset_attrs),
+            self.__params(props, attrs, asset_attrs),
             confirm=confirm,
         )
 
@@ -210,16 +210,16 @@ class _EventsClient:
             )
         )
 
-    def __query(
+    def __params(
         self, props: Optional[Dict], attrs: Optional[Dict], asset_attrs: Optional[Dict]
     ) -> Dict:
-        query = deepcopy(props) if props else {}
+        params = deepcopy(props) if props else {}
         if attrs:
-            query["event_attributes"] = attrs
+            params["event_attributes"] = attrs
         if asset_attrs:
-            query["asset_attributes"] = asset_attrs
+            params["asset_attributes"] = asset_attrs
 
-        return _deepmerge(self._archivist.fixtures.get(EVENTS_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(EVENTS_LABEL), params)
 
     def count(
         self,
@@ -246,7 +246,7 @@ class _EventsClient:
 
         return self._archivist.count(
             SEP.join((ASSETS_SUBPATH, asset_id, EVENTS_LABEL)),
-            query=self.__query(props, attrs, asset_attrs),
+            params=self.__params(props, attrs, asset_attrs),
         )
 
     def wait_for_confirmed(
@@ -318,7 +318,7 @@ class _EventsClient:
                 SEP.join((ASSETS_SUBPATH, asset_id, EVENTS_LABEL)),
                 EVENTS_LABEL,
                 page_size=page_size,
-                query=self.__query(props, attrs, asset_attrs),
+                params=self.__params(props, attrs, asset_attrs),
             )
         )
 
@@ -348,6 +348,6 @@ class _EventsClient:
             **self._archivist.get_by_signature(
                 SEP.join((ASSETS_SUBPATH, asset_id, EVENTS_LABEL)),
                 EVENTS_LABEL,
-                query=self.__query(props, attrs, asset_attrs),
+                params=self.__params(props, attrs, asset_attrs),
             )
         )

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -75,7 +75,7 @@ class _LocationsClient:
 
         """
         LOGGER.debug("Create Location %s", props)
-        return self.create_from_data(self.__query(props, attrs))
+        return self.create_from_data(self.__params(props, attrs))
 
     def create_from_data(self, data: Dict) -> Location:
         """Create location
@@ -116,12 +116,12 @@ class _LocationsClient:
             )
         )
 
-    def __query(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
-        query = props or {}
+    def __params(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
+        params = props or {}
         if attrs:
-            query["attributes"] = attrs
+            params["attributes"] = attrs
 
-        return _deepmerge(self._archivist.fixtures.get(LOCATIONS_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(LOCATIONS_LABEL), params)
 
     def count(
         self, *, props: Optional[Dict] = None, attrs: Optional[Dict] = None
@@ -139,7 +139,7 @@ class _LocationsClient:
 
         """
         return self._archivist.count(
-            f"{LOCATIONS_SUBPATH}/{LOCATIONS_LABEL}", query=self.__query(props, attrs)
+            f"{LOCATIONS_SUBPATH}/{LOCATIONS_LABEL}", params=self.__params(props, attrs)
         )
 
     def list(
@@ -169,7 +169,7 @@ class _LocationsClient:
                 f"{LOCATIONS_SUBPATH}/{LOCATIONS_LABEL}",
                 LOCATIONS_LABEL,
                 page_size=page_size,
-                query=self.__query(props, attrs),
+                params=self.__params(props, attrs),
             )
         )
 
@@ -192,6 +192,6 @@ class _LocationsClient:
             **self._archivist.get_by_signature(
                 f"{LOCATIONS_SUBPATH}/{LOCATIONS_LABEL}",
                 LOCATIONS_LABEL,
-                query=self.__query(props, attrs),
+                params=self.__params(props, attrs),
             )
         )

--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -162,9 +162,9 @@ class _SBOMSClient:
             )
         )
 
-    def __query(self, metadata: Optional[Dict]) -> Dict:
-        query = deepcopy(metadata) if metadata else {}
-        return _deepmerge(self._archivist.fixtures.get(SBOMS_LABEL), query)
+    def __params(self, metadata: Optional[Dict]) -> Dict:
+        params = deepcopy(metadata) if metadata else {}
+        return _deepmerge(self._archivist.fixtures.get(SBOMS_LABEL), params)
 
     def list(
         self,
@@ -192,14 +192,14 @@ class _SBOMSClient:
             iterable that returns :class:`SBOM` instances
 
         """
-        query = self.__query(metadata)
+        params = self.__params(metadata)
         return (
             SBOM(**a)
             for a in self._archivist.list(
                 f"{SBOMS_SUBPATH}/{SBOMS_LABEL}/{SBOMS_WILDCARD}",
                 SBOMS_LABEL,
                 page_size=page_size,
-                query=query,
+                params=params,
             )
         )
 

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -77,7 +77,7 @@ class _SubjectsClient:
         """
         LOGGER.debug("Create Subject %s", display_name)
         return self.create_from_data(
-            self.__query(
+            self.__params(
                 display_name=display_name,
                 wallet_pub_keys=wallet_pub_keys,
                 tessera_pub_keys=tessera_pub_keys,
@@ -149,7 +149,7 @@ class _SubjectsClient:
             **self._archivist.patch(
                 SUBJECTS_SUBPATH,
                 identity,
-                self.__query(
+                self.__params(
                     display_name=display_name,
                     wallet_pub_keys=wallet_pub_keys,
                     tessera_pub_keys=tessera_pub_keys,
@@ -171,7 +171,7 @@ class _SubjectsClient:
         """
         return self._archivist.delete(SUBJECTS_SUBPATH, identity)
 
-    def __query(
+    def __params(
         self,
         *,
         display_name: Optional[str] = None,
@@ -179,18 +179,18 @@ class _SubjectsClient:
         tessera_pub_keys: Optional[List[str]] = None,
     ) -> Dict:
 
-        query = {}
+        params = {}
 
         if display_name is not None:
-            query["display_name"] = display_name
+            params["display_name"] = display_name
 
         if wallet_pub_keys is not None:
-            query["wallet_pub_key"] = wallet_pub_keys
+            params["wallet_pub_key"] = wallet_pub_keys
 
         if tessera_pub_keys is not None:
-            query["tessera_pub_key"] = tessera_pub_keys
+            params["tessera_pub_key"] = tessera_pub_keys
 
-        return _deepmerge(self._archivist.fixtures.get(SUBJECTS_LABEL), query)
+        return _deepmerge(self._archivist.fixtures.get(SUBJECTS_LABEL), params)
 
     def count(self, *, display_name: Optional[str] = None) -> int:
         """Count subjects.
@@ -206,7 +206,7 @@ class _SubjectsClient:
         """
         return self._archivist.count(
             f"{SUBJECTS_SUBPATH}/{SUBJECTS_LABEL}",
-            query=self.__query(display_name=display_name),
+            params=self.__params(display_name=display_name),
         )
 
     def list(
@@ -233,6 +233,6 @@ class _SubjectsClient:
                 f"{SUBJECTS_SUBPATH}/{SUBJECTS_LABEL}",
                 SUBJECTS_LABEL,
                 page_size=page_size,
-                query=self.__query(display_name=display_name),
+                params=self.__params(display_name=display_name),
             )
         )

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -9,11 +9,16 @@ from unittest import skip, TestCase
 from uuid import uuid4
 
 from archivist.archivist import Archivist
+from archivist.logger import set_logger
 from archivist.proof_mechanism import ProofMechanism
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
+
+if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
+    set_logger(environ["TEST_DEBUG"])
+
 
 ATTRS = {
     "arc_firmware_version": "1.0",

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -70,7 +70,7 @@ class TestAttachmentstCreate(TestCase):
 
         with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
             attachment = self.arch.attachments.download(
-                file_uuid, fd, query={"allow_insecure": "true"}
+                file_uuid, fd, params={"allow_insecure": "true"}
             )
 
         # Check the downloaded file is identical to the one that was uploaded
@@ -91,5 +91,5 @@ class TestAttachmentstCreate(TestCase):
         with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
             with self.assertRaises(ArchivistBadRequestError):
                 attachment = self.arch.attachments.download(
-                    file_uuid, fd, query={"strict": "true"}
+                    file_uuid, fd, params={"strict": "true"}
                 )

--- a/functests/test_resources/bom.xml
+++ b/functests/test_resources/bom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:591eb851-2646-4d52-aa40-ac8b35a2b2d7" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:591eb851-2646-4d52-aa40-ac8b35a2b2d7" version="1">
     <metadata>
         <timestamp>2020-08-03T01:28:47.678Z</timestamp>
         <tools>

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -15,6 +15,7 @@ docker run \
     -e UNITTEST \
     -e TEST_ARCHIVIST \
     -e TEST_AUTHTOKEN_FILENAME \
+    -e TEST_AUTHTOKEN_FILENAME_2 \
     -e TEST_DEBUG \
     jitsuin-archivist-python-builder \
     "$@"

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -2,7 +2,6 @@
 Test access policies
 """
 
-import json
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -118,13 +117,11 @@ class TestAccessPolicies(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json.loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": REQUEST,
+                    "json": REQUEST,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -156,7 +153,6 @@ class TestAccessPolicies(TestCase):
                     ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -180,7 +176,6 @@ class TestAccessPolicies(TestCase):
                     ((f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,
@@ -206,13 +201,11 @@ class TestAccessPolicies(TestCase):
                 (f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}",),
                 msg="PATCH method args called incorrectly",
             )
-            kwargs["data"] = json.loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": PROPS,
+                    "json": PROPS,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -246,13 +239,13 @@ class TestAccessPolicies(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    (f"url/{ROOT}/{SUBPATH}",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
@@ -283,18 +276,15 @@ class TestAccessPolicies(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&display_name=Policy display name"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "display_name": "Policy display name",
                         },
                         "verify": True,
                     },
@@ -334,9 +324,9 @@ class TestAccessPolicies(TestCase):
                         (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": None,
                             "verify": True,
                         },
                     ),
@@ -376,17 +366,12 @@ class TestAccessPolicies(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}"
-                                "?display_name=Policy display name"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {"display_name": "Policy display name"},
                             "verify": True,
                         },
                     ),
@@ -414,15 +399,14 @@ class TestAccessPolicies(TestCase):
                         (
                             f"url/{ROOT}/"
                             f"{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
-                            "?page_size=1"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
@@ -471,9 +455,9 @@ class TestAccessPolicies(TestCase):
                         ),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": None,
                             "verify": True,
                         },
                     ),
@@ -500,15 +484,14 @@ class TestAccessPolicies(TestCase):
                     (
                         (
                             f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
-                            "?page_size=1"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
@@ -554,9 +537,9 @@ class TestAccessPolicies(TestCase):
                         ),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": None,
                             "verify": True,
                         },
                     ),

--- a/unittests/testappidp.py
+++ b/unittests/testappidp.py
@@ -77,7 +77,6 @@ class TestAppIDP(TestCase):
                 kwargs,
                 {
                     "data": REQUEST,
-                    "headers": None,
                     "verify": True,
                 },
                 msg="CREATE method kwargs called incorrectly",

--- a/unittests/testapplications.py
+++ b/unittests/testapplications.py
@@ -2,7 +2,6 @@
 Test applications
 """
 
-import json
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -47,7 +46,7 @@ REQUEST = {
     "display_name": DISPLAY_NAME,
     "custom_claims": CUSTOM_CLAIMS,
 }
-UPDATE_DATA = json.dumps({"display_name": DISPLAY_NAME})
+UPDATE_DATA = {"display_name": DISPLAY_NAME}
 
 
 class TestApplications(TestCase):
@@ -87,13 +86,11 @@ class TestApplications(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json.loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": REQUEST,
+                    "json": REQUEST,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -120,7 +117,6 @@ class TestApplications(TestCase):
                     ((f"url/{ROOT}/{APPLICATIONS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -144,7 +140,6 @@ class TestApplications(TestCase):
                     ((f"url/{ROOT}/{APPLICATIONS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,
@@ -169,9 +164,8 @@ class TestApplications(TestCase):
                 (
                     ((f"url/{ROOT}/{APPLICATIONS_SUBPATH}/{IDENTITY}"),),
                     {
-                        "data": UPDATE_DATA,
+                        "json": UPDATE_DATA,
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,
@@ -221,9 +215,9 @@ class TestApplications(TestCase):
                         (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
@@ -263,16 +257,13 @@ class TestApplications(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}"
-                                "?display_name=Application display name"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
+                            },
+                            "params": {
+                                "display_name": "Application display name",
                             },
                             "verify": True,
                         },
@@ -299,10 +290,9 @@ class TestApplications(TestCase):
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
-                        "data": None,
+                        "json": None,
                         "verify": True,
                     },
                 ),

--- a/unittests/testarchivistdelete.py
+++ b/unittests/testarchivistdelete.py
@@ -46,7 +46,6 @@ class TestArchivistDelete(TestArchivistMethods):
                     (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,
@@ -81,7 +80,6 @@ class TestArchivistDelete(TestArchivistMethods):
                     (f"url/{ROOT}/path/path/id/xxxxxxxx",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             "headerfield1": "headervalue1",
                         },
@@ -147,7 +145,6 @@ class TestArchivistDelete(TestArchivistMethods):
                     (f"url/{ROOT}/path/path/entity/xxxxxxxx",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -3,7 +3,6 @@ Test archivist
 """
 
 from io import BytesIO
-from json import loads as json_loads
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -49,13 +48,11 @@ class TestArchivistPost(TestArchivistMethods):
                 (f"url/{ROOT}/path/path",),
                 msg="POST method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": request,
+                    "json": request,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -129,13 +126,11 @@ class TestArchivistPost(TestArchivistMethods):
                 (f"url/{ROOT}/path/path",),
                 msg="POST method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": request,
+                    "json": request,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -161,13 +156,11 @@ class TestArchivistPost(TestArchivistMethods):
                 (f"url/{ROOT}/path/path",),
                 msg="POST method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": request,
+                    "json": request,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                         "headerfield1": "headervalue1",
                     },
@@ -200,7 +193,7 @@ class TestArchivistPost(TestArchivistMethods):
             )
             self.assertEqual(
                 len(kwargs),
-                3,
+                4,
                 msg="Incorrect number of keyword arguments",
             )
             headers = kwargs.get("headers")
@@ -259,12 +252,12 @@ class TestArchivistPost(TestArchivistMethods):
             )
             self.assertEqual(
                 args[0],
-                f"url/{ROOT}/path/path?field1=value1&field2=value2",
+                f"url/{ROOT}/path/path",
                 msg="Incorrect first argument",
             )
             self.assertEqual(
                 len(kwargs),
-                3,
+                4,
                 msg="Incorrect number of keyword arguments",
             )
             headers = kwargs.get("headers")
@@ -392,7 +385,7 @@ class TestArchivistPost(TestArchivistMethods):
             )
             self.assertEqual(
                 len(kwargs),
-                3,
+                4,
                 msg="Incorrect number of keyword arguments",
             )
             headers = kwargs.get("headers")
@@ -454,14 +447,11 @@ class TestArchivistPostWithoutAuth(TestCase):
                 (f"url/{ROOT}/path/path",),
                 msg="POST method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": request,
-                    "headers": {
-                        "content-type": "application/json",
-                    },
+                    "json": request,
+                    "headers": {},
                     "verify": True,
                 },
                 msg="POST method kwargs called incorrectly",

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -3,7 +3,6 @@ Test archivist
 """
 
 from copy import copy
-from json import loads as json_loads
 from logging import getLogger
 from os import environ
 
@@ -99,9 +98,8 @@ REQUEST = {
     "attributes": ATTRS,
 }
 REQUEST_KWARGS = {
-    "data": REQUEST,
+    "json": REQUEST,
     "headers": {
-        "content-type": "application/json",
         "authorization": "Bearer authauthauth",
     },
     "verify": True,
@@ -113,9 +111,8 @@ REQUEST_FIXTURES = {
     "attributes": ATTRS_FIXTURES,
 }
 REQUEST_FIXTURES_KWARGS = {
-    "data": REQUEST_FIXTURES,
+    "json": REQUEST_FIXTURES,
     "headers": {
-        "content-type": "application/json",
         "authorization": "Bearer authauthauth",
     },
     "verify": True,
@@ -208,7 +205,6 @@ class TestAssetsCreate(TestAssetsBase):
                 (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 REQUEST_KWARGS,
@@ -240,7 +236,6 @@ class TestAssetsCreate(TestAssetsBase):
             mock_post.return_value = MockResponse(200, **RESPONSE_FIXTURES)
             asset = arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
             args, kwargs = mock_post.call_args
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 args,
                 (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
@@ -413,20 +408,20 @@ class TestAssetsCount(TestAssetsBase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
                 msg="GET method called incorrectly",
             )
 
-    def test_assets_count_with_props_query(self):
+    def test_assets_count_with_props_params(self):
         """
         Test asset counting
         """
@@ -447,18 +442,15 @@ class TestAssetsCount(TestAssetsBase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&confirmation_status=CONFIRMED"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "confirmation_status": "CONFIRMED",
                         },
                         "verify": True,
                     },
@@ -466,7 +458,7 @@ class TestAssetsCount(TestAssetsBase):
                 msg="GET method called incorrectly",
             )
 
-    def test_assets_count_with_attrs_query(self):
+    def test_assets_count_with_attrs_params(self):
         """
         Test asset counting
         """
@@ -485,18 +477,15 @@ class TestAssetsCount(TestAssetsBase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&attributes.arc_firmware_version=1.0"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "attributes.arc_firmware_version": "1.0",
                         },
                         "verify": True,
                     },
@@ -515,7 +504,11 @@ class TestAssetsWait(TestAssetsBase):
         Test asset counting
         """
         ## last call to get looks for FAILED assets
-        status = ("", "&confirmation_status=PENDING", "&confirmation_status=FAILED")
+        status = (
+            {"page_size": 1},
+            {"page_size": 1, "confirmation_status": "PENDING"},
+            {"page_size": 1, "confirmation_status": "FAILED"},
+        )
         with mock.patch.object(self.arch._session, "get") as mock_get:
             mock_get.side_effect = [
                 MockResponse(
@@ -542,13 +535,13 @@ class TestAssetsWait(TestAssetsBase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        ((f"url/{ROOT}/{SUBPATH}" "?page_size=1" f"{status[i]}"),),
+                        (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                                 HEADERS_REQUEST_TOTAL_COUNT: "true",
                             },
+                            "params": status[i],
                             "verify": True,
                         },
                     ),
@@ -696,16 +689,16 @@ class TestAssetsList(TestAssetsBase):
                         (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
                     msg="GET method called incorrectly",
                 )
 
-    def test_assets_list_with_query(self):
+    def test_assets_list_with_params(self):
         """
         Test asset listing
         """
@@ -741,17 +734,14 @@ class TestAssetsList(TestAssetsBase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}"
-                                "?attributes.arc_firmware_version=1.0"
-                                "&confirmation_status=CONFIRMED"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
+                            },
+                            "params": {
+                                "confirmation_status": "CONFIRMED",
+                                "attributes.arc_firmware_version": "1.0",
                             },
                             "verify": True,
                         },
@@ -781,12 +771,12 @@ class TestAssetsList(TestAssetsBase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/{SUBPATH}?page_size=2",),
+                    (f"url/{ROOT}/{SUBPATH}",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
+                        "params": {"page_size": 2},
                         "verify": True,
                     },
                 ),

--- a/unittests/testcompliance.py
+++ b/unittests/testcompliance.py
@@ -96,7 +96,6 @@ class TestCompliance(TestCase):
                         (f"url/{ROOT}/{SUBPATH}/{ASSET_ID}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
                             "verify": True,

--- a/unittests/testcompliance_policies.py
+++ b/unittests/testcompliance_policies.py
@@ -2,7 +2,6 @@
 Test compliance policies
 """
 
-from json import loads as json_loads
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -116,13 +115,11 @@ class TestCompliancePolicies(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": SINCE_REQUEST,
+                    "json": SINCE_REQUEST,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -149,7 +146,6 @@ class TestCompliancePolicies(TestCase):
                     ((f"url/{ROOT}/{COMPLIANCE_POLICIES_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -173,7 +169,6 @@ class TestCompliancePolicies(TestCase):
                     ((f"url/{ROOT}/{COMPLIANCE_POLICIES_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,
@@ -208,13 +203,13 @@ class TestCompliancePolicies(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
@@ -245,19 +240,13 @@ class TestCompliancePolicies(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&compliance_type=SINCE"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1, "compliance_type": "SINCE"},
                         "verify": True,
                     },
                 ),
@@ -296,9 +285,9 @@ class TestCompliancePolicies(TestCase):
                         (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
@@ -338,12 +327,12 @@ class TestCompliancePolicies(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        ((f"url/{ROOT}/{SUBPATH}?compliance_type=SINCE"),),
+                        ((f"url/{ROOT}/{SUBPATH}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {"compliance_type": "SINCE"},
                             "verify": True,
                         },
                     ),
@@ -372,12 +361,12 @@ class TestCompliancePolicies(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/{SUBPATH}?page_size=2",),
+                    (f"url/{ROOT}/{SUBPATH}",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
+                        "params": {"page_size": 2},
                         "verify": True,
                     },
                 ),

--- a/unittests/testdictmerge.py
+++ b/unittests/testdictmerge.py
@@ -43,3 +43,40 @@ class TestDictMerge(TestCase):
             {"key": "value", "key1": "value1"},
             msg="Dictmerge returns incorrect result",
         )
+        self.assertEqual(
+            dictmerge._deepmerge(
+                {"key": "value", "sub": {"subkey": "subvalue"}},
+                {"key1": "value1", "sub1": {"subkey1": "subvalue1"}},
+            ),
+            {
+                "key": "value",
+                "sub": {"subkey": "subvalue"},
+                "key1": "value1",
+                "sub1": {"subkey1": "subvalue1"},
+            },
+            msg="Dictmerge returns incorrect result",
+        )
+
+    def test_dotdict(self):
+        """
+        Test dotdict
+        """
+        self.assertIsNone(
+            dictmerge._dotdict(None),
+            msg="Dotdict returns incorrect result",
+        )
+        self.assertEqual(
+            dictmerge._dotdict({}),
+            {},
+            msg="Dotdict returns incorrect result",
+        )
+        self.assertEqual(
+            dictmerge._dotdict({"key1": "value1"}),
+            {"key1": "value1"},
+            msg="Dotdict returns incorrect result",
+        )
+        self.assertEqual(
+            dictmerge._dotdict({"key": "value", "sub": {"subkey": "subvalue"}}),
+            {"key": "value", "sub.subkey": "subvalue"},
+            msg="Dotdict returns incorrect result",
+        )

--- a/unittests/testevents.py
+++ b/unittests/testevents.py
@@ -2,7 +2,6 @@
 Test archivist
 """
 
-from json import loads as json_loads
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -257,13 +256,11 @@ class TestEvents(TestCase):
                 ),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": REQUEST,
+                    "json": REQUEST,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -302,13 +299,11 @@ class TestEvents(TestCase):
                 ),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": REQUEST_WITH_ASSET_ATTRS,
+                    "json": REQUEST_WITH_ASSET_ATTRS,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -452,7 +447,6 @@ class TestEvents(TestCase):
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -508,22 +502,21 @@ class TestEvents(TestCase):
                             f"url/{ROOT}/{ASSETS_SUBPATH}"
                             f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                             f"/{EVENTS_LABEL}"
-                            "?page_size=1"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
                 msg="GET method called incorrectly",
             )
 
-    def test_events_count_with_props_query(self):
+    def test_events_count_with_props_params(self):
         """
         Test event counting
         """
@@ -550,23 +543,21 @@ class TestEvents(TestCase):
                             f"url/{ROOT}/{ASSETS_SUBPATH}"
                             f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                             f"/{EVENTS_LABEL}"
-                            "?page_size=1"
-                            "&confirmation_status=CONFIRMED"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1, "confirmation_status": "CONFIRMED"},
                         "verify": True,
                     },
                 ),
                 msg="GET method called incorrectly",
             )
 
-    def test_events_count_with_attrs_query(self):
+    def test_events_count_with_attrs_params(self):
         """
         Test event counting
         """
@@ -591,15 +582,16 @@ class TestEvents(TestCase):
                             f"url/{ROOT}/{ASSETS_SUBPATH}"
                             f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                             f"/{EVENTS_LABEL}"
-                            "?page_size=1"
-                            "&event_attributes.arc_firmware_version=1.0"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "event_attributes.arc_firmware_version": "1.0",
                         },
                         "verify": True,
                     },
@@ -631,15 +623,16 @@ class TestEvents(TestCase):
                             f"url/{ROOT}/{ASSETS_SUBPATH}"
                             f"/{ASSETS_WILDCARD}"
                             f"/{EVENTS_LABEL}"
-                            "?page_size=1"
-                            "&event_attributes.arc_firmware_version=1.0"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "event_attributes.arc_firmware_version": "1.0",
                         },
                         "verify": True,
                     },
@@ -652,7 +645,11 @@ class TestEvents(TestCase):
         Test event counting
         """
         ## last call to get looks for FAILED assets
-        status = ("", "&confirmation_status=PENDING", "&confirmation_status=FAILED")
+        status = (
+            {"page_size": 1},
+            {"page_size": 1, "confirmation_status": "PENDING"},
+            {"page_size": 1, "confirmation_status": "FAILED"},
+        )
         with mock.patch.object(self.arch._session, "get") as mock_get:
             mock_get.side_effect = [
                 MockResponse(
@@ -684,16 +681,14 @@ class TestEvents(TestCase):
                                 f"url/{ROOT}/{ASSETS_SUBPATH}"
                                 f"/{ASSETS_WILDCARD}"
                                 f"/{EVENTS_LABEL}"
-                                "?page_size=1"
-                                f"{status[i]}"
                             ),
                         ),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                                 HEADERS_REQUEST_TOTAL_COUNT: "true",
                             },
+                            "params": status[i],
                             "verify": True,
                         },
                     ),
@@ -756,16 +751,16 @@ class TestEvents(TestCase):
                         ),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
                     msg="GET method called incorrectly",
                 )
 
-    def test_events_list_with_query(self):
+    def test_events_list_with_params(self):
         """
         Test event listing
         """
@@ -807,14 +802,15 @@ class TestEvents(TestCase):
                                 f"url/{ROOT}/{ASSETS_SUBPATH}"
                                 f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                                 f"/{EVENTS_LABEL}"
-                                "?confirmation_status=CONFIRMED"
-                                "&event_attributes.arc_firmware_version=1.0"
                             ),
                         ),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
+                            },
+                            "params": {
+                                "confirmation_status": "CONFIRMED",
+                                "event_attributes.arc_firmware_version": "1.0",
                             },
                             "verify": True,
                         },
@@ -863,14 +859,15 @@ class TestEvents(TestCase):
                                 f"url/{ROOT}/{ASSETS_SUBPATH}"
                                 f"/{ASSETS_WILDCARD}"
                                 f"/{EVENTS_LABEL}"
-                                "?confirmation_status=CONFIRMED"
-                                "&event_attributes.arc_firmware_version=1.0"
                             ),
                         ),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
+                            },
+                            "params": {
+                                "confirmation_status": "CONFIRMED",
+                                "event_attributes.arc_firmware_version": "1.0",
                             },
                             "verify": True,
                         },
@@ -905,14 +902,13 @@ class TestEvents(TestCase):
                             f"url/{ROOT}/{ASSETS_SUBPATH}"
                             f"/{ASSETS_LABEL}/xxxxxxxxxxxxxxxxxxxx"
                             f"/{EVENTS_LABEL}"
-                            f"?page_size=2"
                         ),
                     ),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
+                        "params": {"page_size": 2},
                         "verify": True,
                     },
                 ),

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -2,7 +2,6 @@
 Test archivist
 """
 
-from json import loads as json_loads
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -84,13 +83,11 @@ class TestLocations(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": REQUEST,
+                    "json": REQUEST,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -117,7 +114,6 @@ class TestLocations(TestCase):
                     ((f"url/{ROOT}/{LOCATIONS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -153,13 +149,13 @@ class TestLocations(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
@@ -171,7 +167,7 @@ class TestLocations(TestCase):
                 msg="Incorrect count",
             )
 
-    def test_locations_count_with_props_query(self):
+    def test_locations_count_with_props_params(self):
         """
         Test location counting
         """
@@ -190,18 +186,15 @@ class TestLocations(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&display_name=Macclesfield, Cheshire"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "display_name": "Macclesfield, Cheshire",
                         },
                         "verify": True,
                     },
@@ -209,7 +202,7 @@ class TestLocations(TestCase):
                 msg="GET method called incorrectly",
             )
 
-    def test_locations_count_with_attrs_query(self):
+    def test_locations_count_with_attrs_params(self):
         """
         Test location counting
         """
@@ -228,18 +221,15 @@ class TestLocations(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&attributes.director=John Smith"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "attributes.director": "John Smith",
                         },
                         "verify": True,
                     },
@@ -279,16 +269,16 @@ class TestLocations(TestCase):
                         (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
                     msg="GET method called incorrectly",
                 )
 
-    def test_locations_list_with_query(self):
+    def test_locations_list_with_params(self):
         """
         Test location listing
         """
@@ -322,17 +312,14 @@ class TestLocations(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}"
-                                "?attributes.director=John Smith"
-                                "&display_name=Macclesfield, Cheshire"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
+                            },
+                            "params": {
+                                "attributes.director": "John Smith",
+                                "display_name": "Macclesfield, Cheshire",
                             },
                             "verify": True,
                         },
@@ -362,12 +349,12 @@ class TestLocations(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (f"url/{ROOT}/{SUBPATH}?page_size=2",),
+                    (f"url/{ROOT}/{SUBPATH}",),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
+                        "params": {"page_size": 2},
                         "verify": True,
                     },
                 ),

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -256,10 +256,10 @@ class TestSBOMS(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
-                            "content-type": "application/json",
                         },
                         "stream": True,
                         "verify": True,
+                        "params": None,
                     },
                     msg="DOWNLOAD method called incorrectly",
                 )
@@ -283,7 +283,6 @@ class TestSBOMS(TestCase):
                     ((f"url/{ROOT}/{SBOMS_SUBPATH}/{IDENTITY}/{SBOMS_METADATA}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -307,10 +306,9 @@ class TestSBOMS(TestCase):
                     ((f"url/{ROOT}/{SBOMS_SUBPATH}/{IDENTITY}:{SBOMS_PUBLISH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
-                        "data": None,
+                        "json": None,
                         "verify": True,
                     },
                 ),
@@ -367,10 +365,9 @@ class TestSBOMS(TestCase):
                     ((f"url/{ROOT}/{SBOMS_SUBPATH}/{IDENTITY}:{SBOMS_WITHDRAW}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
-                        "data": None,
+                        "json": None,
                         "verify": True,
                     },
                 ),
@@ -445,16 +442,16 @@ class TestSBOMS(TestCase):
                         (f"url/{ROOT}/{SUBPATH}/{SBOMS_WILDCARD}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
                     msg="GET method called incorrectly",
                 )
 
-    def test_sboms_list_with_query(self):
+    def test_sboms_list_with_params(self):
         """
         Test sboms listing
         """
@@ -490,17 +487,14 @@ class TestSBOMS(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}/{SBOMS_WILDCARD}"
-                                "?lifecycle_status=ACTIVE"
-                                "&version=10.0.2"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}/{SBOMS_WILDCARD}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
+                            },
+                            "params": {
+                                "lifecycle_status": "ACTIVE",
+                                "version": "10.0.2",
                             },
                             "verify": True,
                         },

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -2,7 +2,6 @@
 Test subjects
 """
 
-from json import loads as json_loads
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
@@ -89,13 +88,11 @@ class TestSubjects(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="CREATE method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": REQUEST,
+                    "json": REQUEST,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -122,7 +119,6 @@ class TestSubjects(TestCase):
                     ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "params": None,
@@ -146,7 +142,6 @@ class TestSubjects(TestCase):
                     ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                         },
                         "verify": True,
@@ -172,13 +167,11 @@ class TestSubjects(TestCase):
                 (f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}",),
                 msg="PATCH method args called incorrectly",
             )
-            kwargs["data"] = json_loads(kwargs["data"])
             self.assertEqual(
                 kwargs,
                 {
-                    "data": UPDATE,
+                    "json": UPDATE,
                     "headers": {
-                        "content-type": "application/json",
                         "authorization": "Bearer authauthauth",
                     },
                     "verify": True,
@@ -212,13 +205,13 @@ class TestSubjects(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    ((f"url/{ROOT}/{SUBPATH}" "?page_size=1"),),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
                         },
+                        "params": {"page_size": 1},
                         "verify": True,
                     },
                 ),
@@ -249,18 +242,15 @@ class TestSubjects(TestCase):
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
-                    (
-                        (
-                            f"url/{ROOT}/{SUBPATH}"
-                            "?page_size=1"
-                            "&display_name=Subject display name"
-                        ),
-                    ),
+                    ((f"url/{ROOT}/{SUBPATH}"),),
                     {
                         "headers": {
-                            "content-type": "application/json",
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "page_size": 1,
+                            "display_name": "Subject display name",
                         },
                         "verify": True,
                     },
@@ -300,9 +290,9 @@ class TestSubjects(TestCase):
                         (f"url/{ROOT}/{SUBPATH}",),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {},
                             "verify": True,
                         },
                     ),
@@ -342,17 +332,12 @@ class TestSubjects(TestCase):
                 self.assertEqual(
                     tuple(a),
                     (
-                        (
-                            (
-                                f"url/{ROOT}/{SUBPATH}"
-                                "?display_name=Subject display name"
-                            ),
-                        ),
+                        ((f"url/{ROOT}/{SUBPATH}"),),
                         {
                             "headers": {
-                                "content-type": "application/json",
                                 "authorization": "Bearer authauthauth",
                             },
+                            "params": {"display_name": "Subject display name"},
                             "verify": True,
                         },
                     ),


### PR DESCRIPTION
Problem:
The Current implementaion uses requests 2.4.0 semantics whereby
json is passed as a json string to the data= keyword argument
and params are appended to path as json string.

Solution:
Use the json= and params= keywords to support JSON body and
path selector. Only use data= keyword when passing a
pplication/x-www-form-urlencoded data.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>