### PR TITLE
Subjects confirmation missing

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -22,7 +22,7 @@
       arch = Archivist(
           "https://app.rkvst.io",
           authtoken,
-          max_time=1200,
+          max_time=300.0,
       )
 
     The arch variable now has additional endpoints assets,events,locations,
@@ -103,7 +103,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         url (str): URL of archivist endpoint
         auth: string representing JWT token.
         verify: if True the certificate is verified
-        max_time (int): maximum time in seconds to wait for confirmation
+        max_time (float): maximum time in seconds to wait for confirmation
 
     """
 
@@ -116,7 +116,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         *,
         fixtures: Optional[Dict] = None,
         verify: bool = True,
-        max_time: int = MAX_TIME,
+        max_time: float = MAX_TIME,
     ):
 
         if isinstance(auth, tuple):
@@ -175,7 +175,7 @@ class Archivist:  # pylint: disable=too-many-instance-attributes
         return self._verify
 
     @property
-    def max_time(self) -> int:
+    def max_time(self) -> float:
         """bool: Returns maximum time in seconds to wait for confirmation"""
         return self._max_time
 

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -1,6 +1,4 @@
-"""assets interface
-
-   Wrap base methods with constants for assets (path, etc...
+"""assets confirmer interface
 """
 
 from logging import getLogger
@@ -23,6 +21,7 @@ from .errors import ArchivistUnconfirmedError
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 from . import assets
 from . import events
+from .utils import backoff_handler
 
 MAX_TIME = 1200
 
@@ -31,16 +30,6 @@ LOGGER = getLogger(__name__)
 
 def __lookup_max_time():
     return MAX_TIME
-
-
-# pylint: disable=consider-using-f-string
-def __backoff_handler(details):
-    LOGGER.debug("MAX_TIME %s", MAX_TIME)
-    LOGGER.debug(
-        "Backing off {wait:0.1f} seconds afters {tries} tries "
-        "calling function {target} with args {args} and kwargs "
-        "{kwargs}".format(**details)
-    )
 
 
 def __on_giveup_confirmation(details):
@@ -75,7 +64,7 @@ def _wait_for_confirmation(
     backoff.expo,
     logger=None,
     max_time=__lookup_max_time,
-    on_backoff=__backoff_handler,
+    on_backoff=backoff_handler,
     on_giveup=__on_giveup_confirmation,
 )
 def _wait_for_confirmation(self, identity):
@@ -111,7 +100,7 @@ def __on_giveup_confirmed(details):
     backoff.expo,
     logger=None,
     max_time=__lookup_max_time,
-    on_backoff=__backoff_handler,
+    on_backoff=backoff_handler,
     on_giveup=__on_giveup_confirmed,
 )
 def _wait_for_confirmed(self, *, props=None, **kwargs) -> bool:

--- a/archivist/publisher.py
+++ b/archivist/publisher.py
@@ -7,6 +7,7 @@ from logging import getLogger
 
 import backoff
 
+from .utils import backoff_handler
 from .errors import ArchivistUnpublishedError
 
 
@@ -23,16 +24,6 @@ def __lookup_max_time():
     return MAX_TIME
 
 
-# pylint: disable=consider-using-f-string
-def __backoff_handler(details):
-    LOGGER.debug("MAX_TIME %s", MAX_TIME)
-    LOGGER.debug(
-        "Backing off {wait:0.1f} seconds afters {tries} tries "
-        "calling function {target} with args {args} and kwargs "
-        "{kwargs}".format(**details)
-    )
-
-
 def __on_giveup_publication(details):
     identity = details["args"][1]
     elapsed = details["elapsed"]
@@ -45,7 +36,7 @@ def __on_giveup_publication(details):
     backoff.expo,
     logger=None,
     max_time=__lookup_max_time,
-    on_backoff=__backoff_handler,
+    on_backoff=backoff_handler,
     on_giveup=__on_giveup_publication,
 )
 def _wait_for_publication(self, identity):

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -32,6 +32,7 @@ from .constants import (
     SUBJECTS_SUBPATH,
     SUBJECTS_LABEL,
 )
+from . import subjects_confirmer
 from .dictmerge import _deepmerge
 
 
@@ -103,6 +104,22 @@ class _SubjectsClient:
                 data,
             )
         )
+
+    def wait_for_confirmation(self, identity: str) -> Subject:
+        """Wait for subject to be confirmed.
+
+        Waits for subject to be confirmed.
+
+        Args:
+            identity (str): identity of asset
+
+        Returns:
+            True if subject is confirmed.
+
+        """
+        subjects_confirmer.MAX_TIME = self._archivist.max_time
+        # pylint: disable=protected-access
+        return subjects_confirmer._wait_for_confirmation(self, identity)
 
     def read(self, identity: str) -> Subject:
         """Read Subject

--- a/archivist/subjects_confirmer.py
+++ b/archivist/subjects_confirmer.py
@@ -1,0 +1,53 @@
+"""assets confirmer interface
+"""
+
+from logging import getLogger
+
+import backoff
+
+from .constants import (
+    CONFIRMATION_CONFIRMED,
+    CONFIRMATION_STATUS,
+)
+from .errors import ArchivistUnconfirmedError
+
+
+# pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
+# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+from . import subjects
+from .utils import backoff_handler
+
+MAX_TIME = 1200
+
+LOGGER = getLogger(__name__)
+
+
+def __lookup_max_time():
+    return MAX_TIME
+
+
+def __on_giveup_confirmation(details):
+    identity = details["args"][1]
+    elapsed = details["elapsed"]
+    raise ArchivistUnconfirmedError(
+        f"confirmation for {identity} timed out after {elapsed} seconds"
+    )
+
+
+@backoff.on_predicate(
+    backoff.expo,
+    logger=None,
+    max_time=__lookup_max_time,
+    on_backoff=backoff_handler,
+    on_giveup=__on_giveup_confirmation,
+)
+def _wait_for_confirmation(self, identity):
+    """Return None until subjects is confirmed"""
+    subject = self.read(identity)
+    if CONFIRMATION_STATUS not in subject:
+        return None
+
+    if subject[CONFIRMATION_STATUS] == CONFIRMATION_CONFIRMED:
+        return subject
+
+    return None

--- a/archivist/uploader.py
+++ b/archivist/uploader.py
@@ -11,6 +11,7 @@ from .errors import ArchivistNotFoundError
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 from . import sboms
+from .utils import backoff_handler
 
 MAX_TIME = 1200
 
@@ -19,16 +20,6 @@ LOGGER = getLogger(__name__)
 
 def __lookup_max_time():
     return MAX_TIME
-
-
-# pylint: disable=consider-using-f-string
-def __backoff_handler(details):
-    LOGGER.debug("MAX_TIME %s", MAX_TIME)
-    LOGGER.debug(
-        "Backing off {wait:0.1f} seconds afters {tries} tries "
-        "calling function {target} with args {args} and kwargs "
-        "{kwargs}".format(**details)
-    )
 
 
 def __on_giveup_uploading(details):
@@ -43,7 +34,7 @@ def __on_giveup_uploading(details):
     backoff.expo,
     logger=None,
     max_time=__lookup_max_time,
-    on_backoff=__backoff_handler,
+    on_backoff=backoff_handler,
     on_giveup=__on_giveup_uploading,
 )
 def _wait_for_uploading(self, identity):

--- a/archivist/utils.py
+++ b/archivist/utils.py
@@ -1,0 +1,31 @@
+"""Some covenience for confirmers
+"""
+
+from logging import getLogger
+
+LOGGER = getLogger(__name__)
+
+
+# pylint: disable=missing-function-docstring
+def __tuple_member(tup, idx, default):
+    try:
+        ret = tup[idx]
+    except IndexError:
+        ret = default
+
+    return ret
+
+
+def backoff_handler(details):
+    wait = details["wait"]
+    tries = details["tries"]
+    args = details["args"]
+    client = __tuple_member(args, 0, "")
+    identity = __tuple_member(args, 1, "")
+    LOGGER.debug(
+        "Backing off %0.1f seconds after %s tries with %s id %s",
+        wait,
+        tries,
+        client,
+        identity,
+    )

--- a/archivist/withdrawer.py
+++ b/archivist/withdrawer.py
@@ -7,6 +7,7 @@ from logging import getLogger
 
 import backoff
 
+from .utils import backoff_handler
 from .errors import ArchivistUnwithdrawnError
 
 
@@ -23,16 +24,6 @@ def __lookup_max_time():
     return MAX_TIME
 
 
-# pylint: disable=consider-using-f-string
-def __backoff_handler(details):
-    LOGGER.debug("MAX_TIME %s", MAX_TIME)
-    LOGGER.debug(
-        "Backing off {wait:0.1f} seconds afters {tries} tries "
-        "calling function {target} with args {args} and kwargs "
-        "{kwargs}".format(**details)
-    )
-
-
 def __on_giveup_withdrawn(details):
     identity = details["args"][1]
     elapsed = details["elapsed"]
@@ -45,7 +36,7 @@ def __on_giveup_withdrawn(details):
     backoff.expo,
     logger=None,
     max_time=__lookup_max_time,
-    on_backoff=__backoff_handler,
+    on_backoff=backoff_handler,
     on_giveup=__on_giveup_withdrawn,
 )
 def _wait_for_withdrawn(self, identity):

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -6,16 +6,12 @@ from copy import deepcopy
 from os import environ
 from unittest import TestCase
 from uuid import uuid4
-from time import sleep
 
 from archivist.archivist import Archivist
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
-
-POLL_FREQUENCY = 10
-POLL_INTERVAL = 0.5
 
 SELF_SUBJECT = "subjects/00000000-0000-0000-0000-000000000000"
 
@@ -46,7 +42,7 @@ FILTERS = [
 
 ACCESS_PERMISSIONS = [
     {
-        "subjects": [],  # empty subjects for now, will be populated in test setup
+        "subjects": [],
         "behaviours": ["Attachments", "RecordEvidence"],
         "include_attributes": [
             "arc_display_name",
@@ -58,53 +54,7 @@ ACCESS_PERMISSIONS = [
 ]
 
 
-def poll_subject_confirmed(arch, identity):
-    """
-    polls for the subject to be confirmed for POLL_FREQUENCY every POLL_INTERVAL.
-
-    :raises: AsssertionError if the subject is not confirmed within the polling window.
-    """
-
-    for x in range(POLL_FREQUENCY):
-        subject = arch.subjects.read(identity)
-
-        if subject["confirmation_status"] == "CONFIRMED":
-            return
-
-        sleep(POLL_INTERVAL)
-
-    raise AssertionError(f"subject: {subject['identity']} is not confirmed.")
-
-
-def reciprocal_subjects(arch_1, arch_2):
-    """
-    creates reciprocal subjects for arch 1 and arch 2.
-
-    Returns the id's of the imported subjects as a tuple
-    """
-    self_subject_1 = arch_1.subjects.read(SELF_SUBJECT)
-    self_subject_2 = arch_2.subjects.read(SELF_SUBJECT)
-
-    subject_1 = arch_1.subjects.create(
-        "org2_subject",
-        self_subject_2["wallet_pub_key"],
-        self_subject_2["tessera_pub_key"],
-    )
-
-    subject_2 = arch_2.subjects.create(
-        "org1_subject",
-        self_subject_1["wallet_pub_key"],
-        self_subject_1["tessera_pub_key"],
-    )
-
-    # check the subjects are confirmed
-    poll_subject_confirmed(arch_1, subject_1["identity"])
-    poll_subject_confirmed(arch_2, subject_2["identity"])
-
-    return subject_1, subject_2
-
-
-class TestAccessPolicies(TestCase):
+class TestAccessPoliciesBase(TestCase):
     """
     Test Archivist AccessPolicies Create method
     """
@@ -116,69 +66,16 @@ class TestAccessPolicies(TestCase):
             auth = fd.read().strip()
         self.arch = Archivist(environ["TEST_ARCHIVIST"], auth, verify=False)
 
-        with open(environ["TEST_AUTHTOKEN_FILENAME_2"], encoding="utf-8") as fd:
-            auth_2 = fd.read().strip()
-        self.arch_2 = Archivist(environ["TEST_ARCHIVIST"], auth_2, verify=False)
-
         self.props = deepcopy(PROPS)
         self.props["display_name"] = f"{DISPLAY_NAME} {uuid4()}"
 
-        # now get reciprocal subjects
-        self.subject_id = reciprocal_subjects(self.arch, self.arch_2)[0]
-        ACCESS_PERMISSIONS[0]["subjects"] = [self.subject_id["identity"]]
 
-    def test_access_policies_create(self):
-        """
-        Test access_policy creation
-        """
-        access_policy = self.arch.access_policies.create(
-            self.props, FILTERS, ACCESS_PERMISSIONS
-        )
-        self.assertEqual(
-            access_policy["display_name"],
-            self.props["display_name"],
-            msg="Incorrect display name",
-        )
+class TestAccessPoliciesSimple(TestAccessPoliciesBase):
+    """
+    Test Archivist AccessPolicies Create method
+    """
 
-    def test_access_policies_update(self):
-        """
-        Test access_policy update
-        """
-        access_policy = self.arch.access_policies.create(
-            self.props, FILTERS, ACCESS_PERMISSIONS
-        )
-        self.assertEqual(
-            access_policy["display_name"],
-            self.props["display_name"],
-            msg="Incorrect display name",
-        )
-        access_policy = self.arch.access_policies.update(
-            access_policy["identity"],
-            props=self.props,
-            filters=FILTERS,
-            access_permissions=ACCESS_PERMISSIONS,
-        )
-
-    def test_access_policies_delete(self):
-        """
-        Test access_policy delete
-        """
-        access_policy = self.arch.access_policies.create(
-            self.props, FILTERS, ACCESS_PERMISSIONS
-        )
-        self.assertEqual(
-            access_policy["display_name"],
-            self.props["display_name"],
-            msg="Incorrect display name",
-        )
-        access_policy = self.arch.access_policies.delete(
-            access_policy["identity"],
-        )
-        self.assertEqual(
-            access_policy,
-            {},
-            msg="Incorrect access_policy",
-        )
+    maxDiff = None
 
     def test_access_policies_list(self):
         """
@@ -197,7 +94,7 @@ class TestAccessPolicies(TestCase):
             self.assertGreater(
                 len(access_policy["display_name"]),
                 0,
-                msg="Incorrect display name",
+                msg="No access policies found",
             )
 
     def test_access_policies_count(self):
@@ -208,5 +105,102 @@ class TestAccessPolicies(TestCase):
         self.assertGreaterEqual(
             count,
             0,
-            msg="Count is zero",
+            msg="Count is not zero",
+        )
+
+
+class TestAccessPolicies(TestAccessPoliciesBase):
+    """
+    Test Archivist AccessPolicies Create method
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        with open(environ["TEST_AUTHTOKEN_FILENAME_2"], encoding="utf-8") as fd:
+            auth_2 = fd.read().strip()
+        self.arch_2 = Archivist(environ["TEST_ARCHIVIST"], auth_2, verify=False)
+
+        # creates reciprocal subjects for arch 1 and arch 2.
+        self_subject_1 = self.arch.subjects.read(SELF_SUBJECT)
+        self_subject_2 = self.arch_2.subjects.read(SELF_SUBJECT)
+
+        subject_1 = self.arch.subjects.create(
+            "org2_subject",
+            self_subject_2["wallet_pub_key"],
+            self_subject_2["tessera_pub_key"],
+        )
+
+        subject_2 = self.arch_2.subjects.create(
+            "org1_subject",
+            self_subject_1["wallet_pub_key"],
+            self_subject_1["tessera_pub_key"],
+        )
+
+        # check the subjects are confirmed
+        self.arch.subjects.wait_for_confirmation(subject_1["identity"])
+        self.arch_2.subjects.wait_for_confirmation(subject_2["identity"])
+
+        # modify access_permissions...
+        self.access_permissions = deepcopy(ACCESS_PERMISSIONS)
+        self.access_permissions[0]["subjects"] = [subject_1["identity"]]
+
+    def test_access_policies_create(self):
+        """
+        Test access_policy creation
+        """
+        access_policy = self.arch.access_policies.create(
+            self.props,
+            FILTERS,
+            self.access_permissions,
+        )
+        self.assertEqual(
+            access_policy["display_name"],
+            self.props["display_name"],
+            msg="Incorrect display name",
+        )
+
+    def test_access_policies_update(self):
+        """
+        Test access_policy update
+        """
+        access_policy = self.arch.access_policies.create(
+            self.props,
+            FILTERS,
+            self.access_permissions,
+        )
+        self.assertEqual(
+            access_policy["display_name"],
+            self.props["display_name"],
+            msg="Incorrect display name",
+        )
+        access_policy = self.arch.access_policies.update(
+            access_policy["identity"],
+            props=self.props,
+            filters=FILTERS,
+            access_permissions=ACCESS_PERMISSIONS,
+        )
+
+    def test_access_policies_delete(self):
+        """
+        Test access_policy delete
+        """
+        access_policy = self.arch.access_policies.create(
+            self.props,
+            FILTERS,
+            self.access_permissions,
+        )
+        self.assertEqual(
+            access_policy["display_name"],
+            self.props["display_name"],
+            msg="Incorrect display name",
+        )
+        access_policy = self.arch.access_policies.delete(
+            access_policy["identity"],
+        )
+        self.assertEqual(
+            access_policy,
+            {},
+            msg="Empty access_policy",
         )

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -130,8 +130,9 @@ class TestArchivist(TestCase):
             "authauthauth",
             msg="Incorrect auth",
         )
-        self.assertTrue(
+        self.assertEqual(
             arch.verify,
+            True,
             msg="verify must be True",
         )
         with self.assertRaises(AttributeError):

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -202,8 +202,9 @@ class TestArchivistPost(TestArchivistMethods):
                 None,
                 msg="Header does not exist",
             )
-            self.assertTrue(
+            self.assertEqual(
                 headers["content-type"].startswith("multipart/form-data"),
+                True,
                 msg="Incorrect content-type",
             )
             data = kwargs.get("data")
@@ -266,8 +267,9 @@ class TestArchivistPost(TestArchivistMethods):
                 None,
                 msg="Header does not exist",
             )
-            self.assertTrue(
+            self.assertEqual(
                 headers["content-type"].startswith("multipart/form-data"),
+                True,
                 msg="Incorrect content-type",
             )
             data = kwargs.get("data")
@@ -394,8 +396,9 @@ class TestArchivistPost(TestArchivistMethods):
                 None,
                 msg="Header does not exist",
             )
-            self.assertTrue(
+            self.assertEqual(
                 headers["content-type"].startswith("multipart/form-data"),
+                True,
                 msg="Incorrect content-type",
             )
             data = kwargs.get("data")

--- a/unittests/testattachments.py
+++ b/unittests/testattachments.py
@@ -63,13 +63,15 @@ class TestAttachments(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="UPLOAD method called incorrectly",
             )
-            self.assertTrue(
+            self.assertEqual(
                 "headers" in kwargs,
+                True,
                 msg="UPLOAD no headers found",
             )
             headers = kwargs["headers"]
-            self.assertTrue(
+            self.assertEqual(
                 "authorization" in headers,
+                True,
                 msg="UPLOAD no authorization found",
             )
             self.assertEqual(
@@ -77,21 +79,25 @@ class TestAttachments(TestCase):
                 "Bearer authauthauth",
                 msg="UPLOAD incorrect authorization",
             )
-            self.assertTrue(
+            self.assertEqual(
                 headers["content-type"].startswith("multipart/form-data;"),
+                True,
                 msg="UPLOAD incorrect content-type",
             )
-            self.assertTrue(
+            self.assertEqual(
                 kwargs["verify"],
+                True,
                 msg="UPLOAD method called incorrectly",
             )
-            self.assertTrue(
+            self.assertEqual(
                 "data" in kwargs,
+                True,
                 msg="UPLOAD no data found",
             )
             fields = kwargs["data"].fields
-            self.assertTrue(
+            self.assertEqual(
                 "file" in fields,
+                True,
                 msg="UPLOAD no file found",
             )
             self.assertEqual(

--- a/unittests/testrunnerassets.py
+++ b/unittests/testrunnerassets.py
@@ -159,7 +159,7 @@ class TestRunnerAssetsCreate(TestCase):
                     }
                 )
 
-            self.assertTrue("Missing Action" in str(ex.exception))
+            self.assertEqual("Missing Action" in str(ex.exception), True)
 
     def test_runner_assets_create_invalid_action(self):
         """
@@ -183,7 +183,7 @@ class TestRunnerAssetsCreate(TestCase):
                     }
                 )
 
-            self.assertTrue("Action ASSETSS" in str(ex.exception))
+            self.assertEqual("Action ASSETSS" in str(ex.exception), True)
 
     @mock.patch("archivist.runner.time_sleep")
     def test_runner_assets_create_invalid_verb_caught(self, mock_sleep):

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -103,13 +103,15 @@ class TestSBOMS(TestCase):
                 (f"url/{ROOT}/{SUBPATH}",),
                 msg="UPLOAD method called incorrectly",
             )
-            self.assertTrue(
+            self.assertEqual(
                 "headers" in kwargs,
+                True,
                 msg="UPLOAD no headers found",
             )
             headers = kwargs["headers"]
-            self.assertTrue(
+            self.assertEqual(
                 "authorization" in headers,
+                True,
                 msg="UPLOAD no authorization found",
             )
             self.assertEqual(
@@ -117,21 +119,25 @@ class TestSBOMS(TestCase):
                 "Bearer authauthauth",
                 msg="UPLOAD incorrect authorization",
             )
-            self.assertTrue(
+            self.assertEqual(
                 headers["content-type"].startswith("multipart/form-data;"),
+                True,
                 msg="UPLOAD incorrect content-type",
             )
-            self.assertTrue(
+            self.assertEqual(
                 kwargs["verify"],
+                True,
                 msg="UPLOAD method called incorrectly",
             )
-            self.assertTrue(
+            self.assertEqual(
                 "data" in kwargs,
+                True,
                 msg="UPLOAD no data found",
             )
             fields = kwargs["data"].fields
-            self.assertTrue(
+            self.assertEqual(
                 "sbom" in fields,
+                True,
                 msg="UPLOAD no field 'sbom' found",
             )
             self.assertEqual(


### PR DESCRIPTION
Problem:
The subjects confirmation for access_policies was done in the
functional tests and was unavailable to a user. Backoff logic
was simple and not exponential.

Solution:
Added wait_for_confirmation() method to the subjects client using
a subjects confirmer similarly to confirmation logic for other
endpoints.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>