### PR TITLE
Use selector instead of signature in story runner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,7 @@ asset or event is confirmed before returning.
       - step:
           action: ASSETS_CREATE
           description: Create an empty radiation bag with id 1.
+          asset_label: radiation bag 1
         behaviours:
           - Attachments
           - RecordEvidence
@@ -260,7 +261,7 @@ asset or event is confirmed before returning.
       - step:
           action: EVENTS_CREATE
           description: Create Event adding 3 rads of radiation to bag 1, increasing its weight by 1kg.
-          asset_name: radiation bag 1
+          asset_label: radiation bag 1
         operation: Record
         behaviour: RecordEvidence
         event_attributes:

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -182,7 +182,8 @@ class _AssetsClient:
             .. code-block:: yaml
 
                 selector:
-                  - attributes.arc_display_name
+                  - attributes:
+                    - arc_display_name
                 behaviours
                   - RecordEvidence
                   - Attachments
@@ -223,15 +224,17 @@ class _AssetsClient:
         attachments = data.pop("attachments", None)
         location = data.pop("location", None)
         selector = data.pop("selector")  # must exist
+        props, attrs = selector_signature(selector, data)
         try:
-            props, attrs = selector_signature(selector, data)
             asset = self.read_by_signature(props=props, attrs=attrs)
 
         except ArchivistNotFoundError:
-            LOGGER.info("asset with selector %s does not exist", selector)
+            LOGGER.info(
+                "asset with selector %s,%s does not exist - creating", props, attrs
+            )
 
         else:
-            LOGGER.info("asset with selector %s already existed", selector)
+            LOGGER.info("asset with selector %s,%s already exists", props, attrs)
             return asset, True
 
         # is location present?

--- a/archivist/cmds/runner/run.py
+++ b/archivist/cmds/runner/run.py
@@ -1,6 +1,7 @@
 # pylint:  disable=missing-docstring
 
 from logging import getLogger
+from os import environ
 from sys import exit as sys_exit
 
 from pyaml_env import parse_config
@@ -19,6 +20,11 @@ def run(arch: "type_helper.Archivist", args):
 
     LOGGER.info("Using version %s of jitsuin-archivist", about.__version__)
     LOGGER.info("Namespace %s", args.namespace)
+
+    # if namespace is specified on the commandline then override any environment
+    # setting...
+    if args.namespace:
+        environ["ARCHIVIST_NAMESPACE"] = args.namespace
 
     with open(args.yamlfile, "r", encoding="utf-8") as y:
         arch.runner(parse_config(data=y))

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -113,7 +113,8 @@ class _LocationsClient:
 
                 selector:
                   - display_name
-                  - attributes.wavestone_ext
+                  - attributes:
+                    - wavestone_ext
                 display_name: Apartements du Gare du Nord
                 description: Residential apartment building in new complex above GdN station
                 latitude: 48.8809
@@ -131,15 +132,17 @@ class _LocationsClient:
         location = None
         data = deepcopy(data)
         selector = data.pop("selector")  # must exist
+        props, attrs = selector_signature(selector, data)
         try:
-            props, attrs = selector_signature(selector, data)
-
             location = self.read_by_signature(props=props, attrs=attrs)
 
         except ArchivistNotFoundError:
-            pass
+            LOGGER.info(
+                "location with selector %s,%s does not exist - creating", props, attrs
+            )
 
         else:
+            LOGGER.info("location with selector %s,%s already exists", props, attrs)
             return location, True
 
         return self.create_from_data(data), False
@@ -164,7 +167,7 @@ class _LocationsClient:
         )
 
     def __params(self, props: Optional[Dict], attrs: Optional[Dict]) -> Dict:
-        params = props or {}
+        params = deepcopy(props) if props else {}
         if attrs:
             params["attributes"] = attrs
 

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -148,7 +148,7 @@ def endpoint(args):
                 },
                 "locations": {
                     "attributes": {
-                        "arc_namespace": args.namespace,
+                        "namespace": args.namespace,
                     },
                 },
             },

--- a/archivist/utils.py
+++ b/archivist/utils.py
@@ -3,6 +3,8 @@
 
 from io import BytesIO
 from logging import getLogger
+from typing import Tuple
+
 from requests import get as requests_get
 
 LOGGER = getLogger(__name__)
@@ -69,3 +71,21 @@ def get_auth(
         return (client_id, authtoken)
 
     return None
+
+
+def selector_signature(selector: list, data: dict) -> Tuple[dict, dict]:
+    """
+    Convert a selctor to a signature fro list and count methods
+
+    Used in locations.create_if_not_exists and assets.create_if_not_exists
+    """
+    # keyerror if selector field does not exist in data
+    props = {k: data[k] for k in selector if not k.startswith("attributes.")}
+    attrselector = [k.split(".", 1)[1] for k in selector if k.startswith("attributes.")]
+    if attrselector:
+        data_attrs = data["attributes"]  # keyerror if not exist (it must exist)
+        attrs = {k: data_attrs[k] for k in attrselector}
+    else:
+        attrs = None
+
+    return (props, attrs)

--- a/archivist/utils.py
+++ b/archivist/utils.py
@@ -75,13 +75,20 @@ def get_auth(
 
 def selector_signature(selector: list, data: dict) -> Tuple[dict, dict]:
     """
-    Convert a selctor to a signature fro list and count methods
+    Convert a selector to a signature for list and count methods
 
     Used in locations.create_if_not_exists and assets.create_if_not_exists
     """
-    # keyerror if selector field does not exist in data
-    props = {k: data[k] for k in selector if not k.startswith("attributes.")}
-    attrselector = [k.split(".", 1)[1] for k in selector if k.startswith("attributes.")]
+    attrselector = []
+    propselector = []
+
+    for k in selector:
+        try:
+            attrselector = k["attributes"]
+        except (KeyError, TypeError):
+            propselector.append(k)
+
+    props = {k: data[k] for k in propselector}
     if attrselector:
         data_attrs = data["attributes"]  # keyerror if not exist (it must exist)
         attrs = {k: data_attrs[k] for k in attrselector}

--- a/docs/runner/assets_create.rst
+++ b/docs/runner/assets_create.rst
@@ -3,9 +3,8 @@
 Assets Create Story Runner YAML
 .........................................
 
-No required parameters except that the arc_diaplay_name value must be
-specified and used as the 'asset_name' value on both 'EVENTS_CREATE' and
-'COMPLIANCE_COMPLIANT_AT' operations.
+'asset_label' is not required but if unspecified the created asset will
+not be accessible to later actions in the story.
 
 .. code-block:: yaml
     
@@ -14,10 +13,13 @@ specified and used as the 'asset_name' value on both 'EVENTS_CREATE' and
       - step:
           action: ASSETS_CREATE
           description: Create new EV Pump with id 1.
+          asset_label: ev pump 1
         behaviours:
           - Attachments
           - RecordEvidence
         attributes:
           arc_display_name: ev pump 1
+          arc_display_type: pump
+          arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
           ev_pump: "true"
         confirm: true

--- a/docs/runner/assets_create_if_not_exists.rst
+++ b/docs/runner/assets_create_if_not_exists.rst
@@ -27,8 +27,9 @@ Usually these field values are derived from an environment variable
           description: Create a door in Paris at Jitsuin offices.
           asset_label: Jitsuin Paris Front Door
         selector:
-          - attributes.arc_display_name
-          - attributes.arc_namespace
+          - attributes:
+            - arc_display_name
+            - arc_namespace
         behaviours:
           - RecordEvidence
           - Attachments
@@ -43,7 +44,8 @@ Usually these field values are derived from an environment variable
         location:
           selector:
             - display_name
-            - attributes.namespace
+            - attributes:
+              - namespace
           display_name: Jitsuin Paris
           description: Sales and sales support for the French region
           latitude: 48.8339211

--- a/docs/runner/assets_create_if_not_exists.rst
+++ b/docs/runner/assets_create_if_not_exists.rst
@@ -3,14 +3,20 @@
 Assets Create If not exists Story Runner YAML
 ..............................................
 
-Searches for an asset matching the given signature. Returns that asset if found,
-else create a new one with the given signature and attributes
+Searches for an asset matching the given selector. Returns that asset if found,
+else create a new one with the given attributes
 
-The 'signature' setting for both the asset and its associated location are required.
+'asset_label' is not required but if unspecified the created asset will
+not be accessible to later actions in the story.
+
+The 'selector' setting for both the asset and its associated location are required.
+
 The 'location', 'attachments' and 'confirm' entries are optional.
 
-The 'signature' for both asset and location will be merged into the attributes of
-the created asset or location.
+The 'arc_namespace' (for the asset) and the 'namespace' (for the location) are used
+to distinguish between assets and locations created between runs of the story.
+Usually these field values are derived from an environment variable 
+'ARCHIVIST_NAMESPACE' (default value is 'namespace').
 
 .. code-block:: yaml
     
@@ -19,25 +25,31 @@ the created asset or location.
       - step:
           action: ASSETS_CREATE_IF_NOT_EXISTS
           description: Create a door in Paris at Jitsuin offices.
-        signature:
-          attributes:
-            arc_display_name: Jitsuin Paris Front Door
+          asset_label: Jitsuin Paris Front Door
+        selector:
+          - attributes.arc_display_name
+          - attributes.arc_namespace
         behaviours:
           - RecordEvidence
           - Attachments
         attributes:
+          arc_display_name: Jitsuin Paris Front Door
+          arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
           arc_display_type: door
           arc_firmware_version: "1.0"
           arc_serial_number: das-j1-01
           arc_description: Electronic door entry system to Jitsuin France
           wavestone_asset_id: paris.france.jitsuin.das
         location:
-          signature:
-            display_name: Jitsuin Paris
+          selector:
+            - display_name
+            - attributes.namespace
+          display_name: Jitsuin Paris
           description: Sales and sales support for the French region
           latitude: 48.8339211
           longitude: 2.371345
           attributes:
+            namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
             address: 5 Parvis Alan Turing, 75013 Paris, France
             wavestone_ext: managed
         attachments:

--- a/docs/runner/assets_list.rst
+++ b/docs/runner/assets_list.rst
@@ -18,3 +18,4 @@ The 'print_response' setting should be specified as True in order to see the res
           print_response: true
         attrs:
           arc_display_type: door
+          arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}

--- a/docs/runner/compliance_compliant_at.rst
+++ b/docs/runner/compliance_compliant_at.rst
@@ -3,7 +3,7 @@
 Compliance Compliant_at Story Runner YAML
 ...........................................
 
-'asset_name' is required from a previously created asset. The asset_id is derived and
+'asset_label' is required from a previously created asset. The asset_id is retrieved and
 inserted as the first argument to compliance.compliant_at().
 
 'report' = true will cause a report to be printed on the compliance status.
@@ -16,4 +16,4 @@ inserted as the first argument to compliance.compliant_at().
           action: COMPLIANCE_COMPLIANT_AT
           description: Check Compliance of EV pump 1.
           report: true
-          asset_name: ev pump 1
+          asset_label: ev pump 1

--- a/docs/runner/events_count.rst
+++ b/docs/runner/events_count.rst
@@ -3,7 +3,8 @@
 Events Count Story Runner YAML
 ...........................................
 
-'asset_name' must match the arc_display_name attribute of an existing asset
+'asset_label' must match the 'asset_label' field of a previous creation step
+(ASSETS_CREATE or ASSETS_CREATE_IF_NOT_EXISTS) 
 for which the authorised Application Registration has Event write access
 
 'props', 'attrs' and 'asset_attrs' are optional.
@@ -18,7 +19,7 @@ This example counts all 'open door' events for the Courts of Justice Front Door.
           action: EVENTS_COUNT
           description: List all events for Courts of Justice Paris Front Door
           print_response: true
-          asset_name: Courts of Justice Paris Front Door
+          asset_label: Courts of Justice Paris Front Door
         props:
           confirmation_status: CONFIRMED
         attrs:

--- a/docs/runner/events_create.rst
+++ b/docs/runner/events_create.rst
@@ -37,7 +37,8 @@ the event.
         location:
           selector:
             - display_name
-            - attributes.namespace
+            - attributes:
+              - namespace
           display_name: Paris Courts of Justice
           description: Public museum in the former Palais de Justice
           latitude: 48.855722

--- a/docs/runner/events_create.rst
+++ b/docs/runner/events_create.rst
@@ -3,8 +3,8 @@
 Events Create Story Runner YAML
 ...........................................
 
-'asset_name' must match the arc_display_name attribute of an existing asset for which
-the authorised Application Registration has Event write access
+'asset_label' must match the asset_label setting when the asset was created in a previous
+creation step (action is either 'ASSETS_CREATE' or 'ASSETS_CREATE_IF_NOT_EXISTS').
 
 The optional 'attachments' setting uploads the attachments to archivist and the response
 added to the event before posting.
@@ -19,7 +19,7 @@ the event.
       - step:
           action: EVENTS_CREATE
           description: Access Card 2 opens Courts of justice front door
-          asset_name: Access Card 2
+          asset_label: Access Card 2
           print_response: true
         operation: Record
         behaviour: RecordEvidence
@@ -35,12 +35,15 @@ the event.
           wavestone_door_name: Courts of Justice Paris Front Door
           wavestone_evt_type: door_open
         location:
-          signature:
-            display_name: Paris Courts of Justice
+          selector:
+            - display_name
+            - attributes.namespace
+          display_name: Paris Courts of Justice
           description: Public museum in the former Palais de Justice
           latitude: 48.855722
           longitude: 2.345051
           attributes:
+            namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
             address: 10 Boulevard du Palais, 75001 Paris, France
             wavestone_ext: managed
         attachments:

--- a/docs/runner/events_list.rst
+++ b/docs/runner/events_list.rst
@@ -3,8 +3,11 @@
 Events List Story Runner YAML
 ...........................................
 
-'asset_name' must match the arc_display_name attribute of an existing asset
+'asset_label' must match the 'asset_label' field of a previous creation step
+(ASSETS_CREATE or ASSETS_CREATE_IF_NOT_EXISTS)
 for which the authorised Application Registration has Event write access
+
+if 'asset_label' is not set, data for all assets is output.
 
 'props', 'attrs' and 'asset_attrs' are optional.
 
@@ -18,7 +21,7 @@ This example lists all 'open door' events for the Courts of Justice Front Door.
           action: EVENTS_LIST
           description: List all events for Courts of Justice Paris Front Door
           print_response: true
-          asset_name: Courts of Justice Paris Front Door
+          asset_label: Courts of Justice Paris Front Door
         props:
           confirmation_status: CONFIRMED
         attrs:

--- a/docs/runner/generic.rst
+++ b/docs/runner/generic.rst
@@ -17,12 +17,13 @@ Each step follows the same pattern:
           description: Create new EV Pump with id 1.
           wait_time: 10
           print_response: true
-          asset_name: Radiation bag 1
-        ................definition of request body
+          asset_label: Radiation bag 1
+        ................definition of request body and other
+                        parameters
   
 
 :action:
-    Required for every operation. This is a prefined constant that maps to
+    Required for every operation. This is a predefined constant that maps to
     a method e.g. "ASSETS_CREATE" will call the assets.create_from_data() method
 
 :description:
@@ -30,7 +31,7 @@ Each step follows the same pattern:
     Emits this string to stdout.
 
 :wait_time:
-    The scenario will pause for this number of seconds before execution.
+    The story runner will pause for this number of seconds before execution.
     Primarily used to demonstrate compliance policy evaluation. One pauses
     before creating events and before evaluating compliance to allow
     (for example) the asset to become non-compliant. (demonstration)
@@ -38,8 +39,12 @@ Each step follows the same pattern:
 :print_response:
    Emit JSON representation of response. Useful for debugging purposes.
 
-:asset_name:
-   Required for 'EVENTS_CREATE' and 'COMPLIANCE_COMPLIANT_AT' operaions. Without
-   this value these operations will fail.
-   The asset_name is the 'attributes.arc_display_name' value of an asset.
+:asset_label:
+   For create type actions (ASSETS_CREATE, ASSETS_CREATE_IF_NOT_EXISTS) the label is used
+   by the runner to keep track of assets.
+
+   For other actions which require access to an asset, this value is used as a key to
+   obtain the identity of such a previously-created asset.
+
+   In this way one can create assets and then refer to them in later steps of the story.
 

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -31,15 +31,15 @@ ATTRS = {
 
 ASSET_NAME = "Telephone with 2 attachments - one bad or not scanned 2022-03-01"
 REQUEST_EXISTS_ATTACHMENTS = {
-    "signature": {
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-            "arc_namespace": "namespace",
-        },
+    "selector": {
+        "attributes.arc_display_name",
+        "attributes.arc_namespace",
     },
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
     "attributes": {
+        "arc_display_name": ASSET_NAME,
+        "arc_namespace": "namespace",
         "arc_firmware_version": "1.0",
         "arc_serial_number": "vtl-x4-07",
         "arc_description": "Traffic flow control light at A603 North East",

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -59,7 +59,7 @@ class TestRunner(TestCase):
             self.arch.runner.run_steps(parse_config(data=y))
             self.assertEqual(
                 len(self.arch.runner.entities),
-                2,
+                1,
                 msg="Incorrect number of entities",
             )
 
@@ -79,7 +79,7 @@ class TestRunner(TestCase):
             self.arch.runner.run_steps(parse_config(data=y))
             self.assertEqual(
                 len(self.arch.runner.entities),
-                5,
+                3,
                 msg="Incorrect number of entities",
             )
 

--- a/functests/test_resources/door_entry_story.yaml
+++ b/functests/test_resources/door_entry_story.yaml
@@ -8,29 +8,36 @@
 # This story creates a number of doors and access cards. An 'open door' event is then 
 # created with attached photo. Finally all doors and cards are listed and all events on 
 # the the Courts of Justice Front Door and all events on the Access Card 2 are listed.
+#
 steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at Jitsuin offices.
-    signature:
-      attributes:
-        arc_display_name: !ENV Jitsuin Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Jitsuin Paris Front Door
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Jitsuin Paris Front Door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-j1-01
       arc_description: Electronic door entry system to Jitsuin France
       wavestone_asset_id: paris.france.jitsuin.das
     location:
-      signature:
-        display_name: !ENV Jitsuin Paris ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Jitsuin Paris
       description: Sales and sales support for the French region
       latitude: 48.8339211
       longitude: 2.371345
       attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
         address: 5 Parvis Alan Turing, 75013 Paris, France
         wavestone_ext: managed
     attachments:
@@ -41,25 +48,31 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at City Hall
-    signature:
-      attributes:
-        arc_display_name: !ENV City Hall Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: City Hall Paris Front Door
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: City Hall Paris Front Door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-01
       arc_description: Electronic door entry system controlling the main staff entrance to Paris City Hall
       wavestone_asset_id: cityhall.paris.wavestonedas
     location:
-      signature:
-        display_name: !ENV Paris City Hall ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Paris City Hall
       description: Seat of Paris local city adminstration
       latitude: 48.856389
       longitude: 2.352222
       attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
         address: Place de l'Hôtel de Ville, 75004 Paris, France
         wavestone_ext: managed
       attachments:
@@ -71,25 +84,31 @@ steps:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at Courts of Justice
       print_response: true
-    signature:
-      attributes:
-        arc_display_name: !ENV Courts of Justice Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Courts of Justice Paris Front Door
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Courts of Justice Paris Front Door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-02
       arc_description: Electronic door entry system controlling the main staff entrance to Paris Courts of Justice
       wavestone_asset_id: courts.paris.wavestonedas
     location:
-      signature:
-        display_name: !ENV Paris Courts of Justice ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Paris Courts of Justice
       description: Public museum in the former Palais de Justice
       latitude: 48.855722
       longitude: 2.345051
       attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
         address: 10 Boulevard du Palais, 75001 Paris, France
         wavestone_ext: managed
     attachments:
@@ -100,25 +119,31 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at Bastille
-    signature:
-      attributes:
-        arc_display_name: !ENV Bastille Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Bastille Paris Front Door
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Bastille Paris Front Door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-03
       arc_description: Electronic door entry system controlling the main staff entrance to Bastille
       wavestone_asset_id: bastille.paris.wavestonedas
     location:
-      signature:
-        display_name: !ENV Bastille ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Bastille
       description: Medieval fortress, made famous by the French Revolution
       latitude: 48.85333
       longitude: 2.36917
       attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
         address: Place de la Bastille, 75011 Paris, France
         wavestone_ext: managed
     attachments:
@@ -129,25 +154,31 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a front door in Paris at Gare du Nord Apartments
-    signature:
-      attributes:
-        arc_display_name: !ENV Gare du Nord Apartments Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Gare du Nord Apartments Paris Front Door
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Gare du Nord Apartments Paris Front Door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-04
       arc_description: Electronic door entry system controlling the front residential entrance to Apartements du Gare du Nord
       wavestone_asset_id: front.gdn.paris.wavestonedas
     location:
-      signature:
-        display_name: !ENV Apartements du Gare du Nord ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Apartements du Gare du Nord
       description: Residential apartment building in new complex above GdN station
       latitude: 48.8809
       longitude: 2.3553
       attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
         address: 18 Rue de Dunkerque, 75010 Paris, France
         wavestone_ext: managed
     attachments:
@@ -158,25 +189,31 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a side door in Paris at Gare du Nord Apartments
-    signature:
-      attributes:
-        arc_display_name: !ENV Gare du Nord Apartments Paris Side Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Gare du Nord Apartments Paris Side Door
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Gare du Nord Apartments Paris Side Door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-05
       arc_description: Electronic door entry system controlling the side residential entrance to Apartements du Gare du Nord
       wavestone_asset_id: side.gdn.paris.wavestonedas
     location:
-      signature:
-        display_name: !ENV Apartements du Gare du Nord ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Apartements du Gare du Nord
       description: Residential apartment building in new complex above GdN station
       latitude: 48.8809
       longitude: 2.3553
       attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
         address: 18 Rue de Dunkerque, 75010 Paris, France
         wavestone_ext: managed
     attachments:
@@ -194,13 +231,16 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 1
-    signature:
-      attributes:
-        arc_display_name: !ENV Access Card 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Access Card 1
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Access Card 1
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-1
       arc_description: Electronic door Access Card 1
@@ -209,14 +249,17 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 2
+      asset_label: Access Card 2
       print_response: true
-    signature:
-      attributes:
-        arc_display_name: !ENV Access Card 2 ${ARCHIVIST_NAMESPACE:namespace}
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Access Card 2
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-2
       arc_description: Electronic door Access Card 2
@@ -225,13 +268,16 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 3
-    signature:
-      attributes:
-        arc_display_name: !ENV Access Card 3 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Access Card 3
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Access Card 3
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_serial_number: sc-x5-3
       arc_description: Electronic door Access Card 3
     confirm: true
@@ -239,13 +285,16 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 4
-    signature:
-      attributes:
-        arc_display_name: !ENV Access Card 4 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Access Card 4
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Access Card 4
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-4
       arc_description: Electronic door Access Card 4
@@ -254,13 +303,16 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 5
-    signature:
-      attributes:
-        arc_display_name: !ENV Access Card 5 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Access Card 5
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Access Card 5
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-5
       arc_description: Electronic door Access Card 5
@@ -272,14 +324,14 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Courts of justice front door opened with card 2
-      asset_name: !ENV Courts of Justice Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Courts of Justice Paris Front Door
       print_response: true
     operation: Record
     behaviour: RecordEvidence
     principal_declared:
       subject: courts.paris.wavestonedas
       email: courts.paris.wavestonedas@iot.wavestone.com
-      display_name: !ENV Courts of Justice Paris Front Door machine credential ${ARCHIVIST_NAMESPACE:namespace}
+      display_name: Courts of Justice Paris Front Door machine credential
     event_attributes:
       arc_description: Door opened by authorised key card Access Card 2
       arc_display_type: Door Open
@@ -295,14 +347,14 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Access Card 2 opens Courts of justice front door
-      asset_name: !ENV Access Card 2 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Access Card 2
       print_response: true
     operation: Record
     behaviour: RecordEvidence
     principal_declared:
       subject: courts.paris.wavestonedas
       email: courts.paris.wavestonedas@iot.wavestone.com
-      display_name: !ENV Courts of Justice Paris Front Door machine credential ${ARCHIVIST_NAMESPACE:namespace}
+      display_name: Courts of Justice Paris Front Door machine credential
     event_attributes:
       arc_description: Opened Courts of Justice Paris Front Door
       arc_display_type: Door Open
@@ -321,6 +373,7 @@ steps:
       print_response: true
     attrs:
       arc_display_type: door
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
 
   - step:
       action: ASSETS_LIST
@@ -328,16 +381,16 @@ steps:
       print_response: true
     attrs:
       arc_display_type: card
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
 
   - step:
       action: EVENTS_LIST
       description: List all events for Courts of Justice Paris Front Door
       print_response: true
-      asset_name: !ENV Courts of Justice Paris Front Door ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Courts of Justice Paris Front Door
 
   - step:
       action: EVENTS_LIST
       description: List all events for Access Card 2
       print_response: true
-      asset_name: !ENV Access Card 2 ${ARCHIVIST_NAMESPACE:namespace}
-
+      asset_label: Access Card 2

--- a/functests/test_resources/door_entry_story.yaml
+++ b/functests/test_resources/door_entry_story.yaml
@@ -15,8 +15,9 @@ steps:
       description: Create a door in Paris at Jitsuin offices.
       asset_label: Jitsuin Paris Front Door
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -31,7 +32,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Jitsuin Paris
       description: Sales and sales support for the French region
       latitude: 48.8339211
@@ -50,8 +52,9 @@ steps:
       description: Create a door in Paris at City Hall
       asset_label: City Hall Paris Front Door
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -66,7 +69,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Paris City Hall
       description: Seat of Paris local city adminstration
       latitude: 48.856389
@@ -86,8 +90,9 @@ steps:
       print_response: true
       asset_label: Courts of Justice Paris Front Door
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -102,7 +107,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Paris Courts of Justice
       description: Public museum in the former Palais de Justice
       latitude: 48.855722
@@ -121,8 +127,9 @@ steps:
       description: Create a door in Paris at Bastille
       asset_label: Bastille Paris Front Door
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -137,7 +144,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Bastille
       description: Medieval fortress, made famous by the French Revolution
       latitude: 48.85333
@@ -156,8 +164,9 @@ steps:
       description: Create a front door in Paris at Gare du Nord Apartments
       asset_label: Gare du Nord Apartments Paris Front Door
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -172,7 +181,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Apartements du Gare du Nord
       description: Residential apartment building in new complex above GdN station
       latitude: 48.8809
@@ -191,8 +201,9 @@ steps:
       description: Create a side door in Paris at Gare du Nord Apartments
       asset_label: Gare du Nord Apartments Paris Side Door
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -207,7 +218,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Apartements du Gare du Nord
       description: Residential apartment building in new complex above GdN station
       latitude: 48.8809
@@ -233,8 +245,9 @@ steps:
       description: Create Access Card 1
       asset_label: Access Card 1
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -252,8 +265,9 @@ steps:
       asset_label: Access Card 2
       print_response: true
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -270,8 +284,9 @@ steps:
       description: Create Access Card 3
       asset_label: Access Card 3
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -287,8 +302,9 @@ steps:
       description: Create Access Card 4
       asset_label: Access Card 4
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -305,8 +321,9 @@ steps:
       description: Create Access Card 5
       asset_label: Access Card 5
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments

--- a/functests/test_resources/dynamic_tolerance_story.yaml
+++ b/functests/test_resources/dynamic_tolerance_story.yaml
@@ -14,11 +14,13 @@ steps:
   - step:
       action: ASSETS_CREATE
       description: Create new EV Pump with id 1.
+      asset_label: ev pump 1
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
-      arc_display_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      arc_display_name: ev pump 1
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       ev_pump: "true"
     confirm: true
 
@@ -29,7 +31,7 @@ steps:
       print_response: true
       delete: true
     description: ev maintenance policy
-    display_name: !ENV ev maintenance policy ${ARCHIVIST_NAMESPACE:namespace}
+    display_name: ev maintenance policy
     compliance_type: COMPLIANCE_DYNAMIC_TOLERANCE
     asset_filter:  
       - or: [ "attributes.ev_pump=true" ]
@@ -42,7 +44,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -55,7 +57,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 1 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 1
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -67,7 +69,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -80,7 +82,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 2 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 2
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -92,7 +94,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -105,7 +107,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 3 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 3
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -118,13 +120,13 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of EV pump 1.
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
 
   # now create an event that throws the Standard deviation out of whack
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -137,7 +139,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 20 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 20
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -150,6 +152,6 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of EV pump 1.
-      asset_name: !ENV ev pump 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: ev pump 1
     report: true
 

--- a/functests/test_resources/richness_story.yaml
+++ b/functests/test_resources/richness_story.yaml
@@ -7,18 +7,17 @@
 #
 # NB the assets and events endpoints require all values to be strings. Other values may
 # be of the correct type such as confirm which is a boolean.
-#
-# For example attributes.radioactive is a string - internally archivist will see this
-# as a boolean.
 steps:
   - step:
       action: ASSETS_CREATE
       description: Create an empty radiation bag with id 1.
+      asset_label: radiation bag 1
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
-      arc_display_name: !ENV radiation bag 1 ${ARCHIVIST_NAMESPACE:namespace}
+      arc_display_name: radiation bag 1
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       radioactive: "true"
       radiation_level: "0"
       weight: "0"
@@ -27,11 +26,13 @@ steps:
   - step:
       action: ASSETS_CREATE
       description: Create an empty radiation bag with id 2.
+      asset_label: radiation bag 2
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
-      arc_display_name: !ENV radiation bag 2 ${ARCHIVIST_NAMESPACE:namespace}
+      arc_display_name: radiation bag 2
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       radioactive: "true"
       radiation_level: "0"
       weight: "0"
@@ -40,11 +41,13 @@ steps:
   - step:
       action: ASSETS_CREATE
       description: Create an empty radiation bag with id 3.
+      asset_label: radiation bag 3
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
-      arc_display_name: !ENV radiation bag 3 ${ARCHIVIST_NAMESPACE:namespace}
+      arc_display_name: radiation bag 3
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       radioactive: "true"
       radiation_level: "0"
       weight: "0"
@@ -57,7 +60,7 @@ steps:
       print_response: true
       delete: true
     description: radiation level safety policy
-    display_name: !ENV radiation safety policy ${ARCHIVIST_NAMESPACE:namespace}
+    display_name: radiation safety policy
     compliance_type: COMPLIANCE_RICHNESS
     asset_filter:
       - or: [ "attributes.radioactive=true" ]
@@ -71,7 +74,7 @@ steps:
       print_response: true
       delete: true
     description: weight level safety policy
-    display_name: !ENV weight safety policy ${ARCHIVIST_NAMESPACE:namespace}
+    display_name: weight safety policy
     compliance_type: COMPLIANCE_RICHNESS
     asset_filter: 
       - or: [ "attributes.radioactive=true" ]
@@ -84,7 +87,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event adding 3 rads of radiation to bag 1, increasing its weight by 1kg.
-      asset_name: !ENV radiation bag 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -97,7 +100,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event adding 2 rads of radiation to bag 2, increasing its weight by 5kg.
-      asset_name: !ENV radiation bag 2 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 2
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -110,7 +113,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event adding 5 rads of radiation to bag 3, increasing its weight by 7kg.
-      asset_name: !ENV radiation bag 3 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 3
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -125,24 +128,24 @@ steps:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 1.
       print_response: True
-      asset_name: !ENV radiation bag 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 1
 
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 2.
-      asset_name: !ENV radiation bag 2 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 2
 
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 3.
-      asset_name: !ENV radiation bag 3 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 3
 
   # now attempt to add waste to tip one over the edge
   - step:
       action: EVENTS_CREATE
       description: Now Create Event adding 4 rads of radiation to bag 3 increasing its weight by 1kg.
                    This brings the total radiation level to 9 rads and weight to 8kg.
-      asset_name: !ENV radiation bag 3 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 3
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -156,5 +159,5 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 3.
-      asset_name: !ENV radiation bag 3 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: radiation bag 3
     report: true

--- a/functests/test_resources/wipp_story.yaml
+++ b/functests/test_resources/wipp_story.yaml
@@ -9,14 +9,16 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a drum container number 1
-    signature:
-      attributes:
-        arc_display_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
-        arc_namespace: wipp
+      asset_label: Drum 1
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Drum 1
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: drum
       arc_description: Standard non-POC 55 gallon drum No. 1
       wipp_capacity: "55"
@@ -29,14 +31,16 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a cask container number 1
-    signature:
-      attributes:
-        arc_display_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
-        arc_namespace: wipp
+      asset_label: Cask 1
+    selector:
+      - attributes.arc_display_name
+      - attributes.arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
     attributes:
+      arc_display_name: Cask 1
+      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
       arc_display_type: cask
       arc_description: NRC certified type-B road shipping container, capacity 3 x 55-gallon drum
       wipp_capacity: "3"
@@ -49,7 +53,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Characterize Drum 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -74,7 +78,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Tomograph Drum 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -100,7 +104,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Loading Drum 1 into Cask 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -119,7 +123,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Filled Cask 1 with Drum 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -138,7 +142,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Preship inspection of Drum 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -155,7 +159,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Preship inspection of Cask 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -172,7 +176,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Departure of Drum 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -192,7 +196,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Departure of Cask 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -213,7 +217,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Atlanta Waypoint of Cask 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -224,11 +228,15 @@ steps:
       wipp_sensors_shock: "0"
       wipp_sensors_rad: "45"
     location:
-      signature:
-        display_name: !ENV Atlanta waypoint ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Atlanta waypoint
       description: Atlanta waypoint
       latitude: 33.592177
       longitude: -84.406064
+      attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
     attachments:
       - filename: functests/test_resources/wipp/truck_departure.jpg
         content_type: image/jpg
@@ -238,7 +246,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Talladega Waypoint of Cask 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -249,11 +257,15 @@ steps:
       wipp_sensors_shock: "0"
       wipp_sensors_rad: "45"
     location:
-      signature:
-        display_name: !ENV Talladega waypoint ${ARCHIVIST_NAMESPACE:namespace}
+      selector:
+        - display_name
+        - attributes.namespace
+      display_name: Talladega waypoint
       description: Talladega waypoint
       latitude: 33.592177
       longitude: -86.248379
+      attributes:
+        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
     attachments:
       - filename: functests/test_resources/wipp/truck_departure.jpg
         content_type: image/jpg
@@ -264,7 +276,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Arrival of Drum 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -281,7 +293,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Arrival of Cask 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -299,7 +311,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Unloading Drum 1 from Cask 1
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -316,7 +328,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Unloading Drum 1 from Cask 1
-      asset_name: !ENV Cask 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Cask 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence
@@ -334,7 +346,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Drum 1 Emplacemant
-      asset_name: !ENV Drum 1 ${ARCHIVIST_NAMESPACE:namespace}
+      asset_label: Drum 1
       print_response: true
     operation: Record
     behaviour: RecordEvidence

--- a/functests/test_resources/wipp_story.yaml
+++ b/functests/test_resources/wipp_story.yaml
@@ -11,8 +11,9 @@ steps:
       description: Create a drum container number 1
       asset_label: Drum 1
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -33,8 +34,9 @@ steps:
       description: Create a cask container number 1
       asset_label: Cask 1
     selector:
-      - attributes.arc_display_name
-      - attributes.arc_namespace
+      - attributes:
+        - arc_display_name
+        - arc_namespace
     behaviours:
       - RecordEvidence
       - Attachments
@@ -230,7 +232,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Atlanta waypoint
       description: Atlanta waypoint
       latitude: 33.592177
@@ -259,7 +262,8 @@ steps:
     location:
       selector:
         - display_name
-        - attributes.namespace
+        - attributes:
+          - namespace
       display_name: Talladega waypoint
       description: Talladega waypoint
       latitude: 33.592177

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,3 @@ twine~=3.4
 # documentation
 sphinx~=4.3
 sphinx-rtd-theme~=1.0.0
-
-# examples
-pyyaml~=5.1.2

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -28,11 +28,9 @@ from .testassetsconstants import (
     REQUEST_EXISTS,
     REQUEST_EXISTS_ATTACHMENTS,
     REQUEST_EXISTS_LOCATION,
-    REQUEST_EXISTS_NOATTRS,
     REQUEST_EXISTS_KWARGS,
     REQUEST_EXISTS_KWARGS_ATTACHMENTS,
     REQUEST_EXISTS_KWARGS_LOCATION,
-    REQUEST_EXISTS_KWARGS_NOATTRS,
     REQUEST_KWARGS,
     REQUEST_FIXTURES_KWARGS,
     RESPONSE,
@@ -41,7 +39,6 @@ from .testassetsconstants import (
     RESPONSE_EXISTS,
     RESPONSE_EXISTS_ATTACHMENTS,
     RESPONSE_EXISTS_LOCATION,
-    RESPONSE_EXISTS_NOATTRS,
     RESPONSE_FIXTURES,
     RESPONSE_NO_CONFIRMATION,
     RESPONSE_PENDING,
@@ -388,16 +385,6 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
         """
         self.common_assets_create_if_not_exists_nonexistent_asset(
             REQUEST_EXISTS, REQUEST_EXISTS_KWARGS, RESPONSE_EXISTS
-        )
-
-    def test_assets_create_if_not_exists_nonexistent_asset_noattributes(self):
-        """
-        Test asset creation
-        """
-        self.common_assets_create_if_not_exists_nonexistent_asset(
-            REQUEST_EXISTS_NOATTRS,
-            REQUEST_EXISTS_KWARGS_NOATTRS,
-            RESPONSE_EXISTS_NOATTRS,
         )
 
     def test_assets_create_if_not_exists_nonexistent_asset_location(self):

--- a/unittests/testassetsconstants.py
+++ b/unittests/testassetsconstants.py
@@ -151,15 +151,15 @@ RESPONSE = {
 
 # case 2 create if not exists
 REQUEST_EXISTS = {
-    "signature": {
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-            "arc_namespace": "namespace",
-        },
-    },
+    "selector": [
+        "attributes.arc_display_name",
+        "attributes.arc_namespace",
+    ],
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
     "attributes": {
+        "arc_display_name": ASSET_NAME,
+        "arc_namespace": "namespace",
         "arc_firmware_version": "1.0",
         "arc_serial_number": "vtl-x4-07",
         "arc_description": "Traffic flow control light at A603 North East",
@@ -202,53 +202,17 @@ RESPONSE_EXISTS = {
     "tracked": "TRACKED",
 }
 
-# case 3 create if not exists with no attributes
-REQUEST_EXISTS_NOATTRS = {
-    "signature": {
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-            "arc_namespace": "namespace",
-        },
-    },
+# case 3 create if not exists with attachments
+REQUEST_EXISTS_ATTACHMENTS = {
+    "selector": [
+        "attributes.arc_display_name",
+        "attributes.arc_namespace",
+    ],
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
-}
-REQUEST_EXISTS_KWARGS_NOATTRS = {
-    "json": {
-        "behaviours": BEHAVIOURS,
-        "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-            "arc_namespace": "namespace",
-        },
-    },
-    "headers": {
-        "authorization": "Bearer authauthauth",
-    },
-    "verify": True,
-}
-RESPONSE_EXISTS_NOATTRS = {
-    "identity": IDENTITY,
-    "behaviours": BEHAVIOURS,
     "attributes": {
         "arc_display_name": ASSET_NAME,
         "arc_namespace": "namespace",
-    },
-    "confirmation_status": "CONFIRMED",
-    "tracked": "TRACKED",
-}
-
-# case 4 create if not exists with attachments
-REQUEST_EXISTS_ATTACHMENTS = {
-    "signature": {
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-            "arc_namespace": "namespace",
-        },
-    },
-    "behaviours": BEHAVIOURS,
-    "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
-    "attributes": {
         "arc_firmware_version": "1.0",
         "arc_serial_number": "vtl-x4-07",
         "arc_description": "Traffic flow control light at A603 North East",
@@ -325,17 +289,17 @@ RESPONSE_EXISTS_ATTACHMENTS = {
     "tracked": "TRACKED",
 }
 
-# case 5 create if not exists with location
+# case 4 create if not exists with location
 REQUEST_EXISTS_LOCATION = {
-    "signature": {
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-            "arc_namespace": "namespace",
-        },
-    },
+    "selector": [
+        "attributes.arc_display_name",
+        "attributes.arc_namespace",
+    ],
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
     "attributes": {
+        "arc_display_name": ASSET_NAME,
+        "arc_namespace": "namespace",
         "arc_firmware_version": "1.0",
         "arc_serial_number": "vtl-x4-07",
         "arc_description": "Traffic flow control light at A603 North East",
@@ -343,16 +307,16 @@ REQUEST_EXISTS_LOCATION = {
         "some_custom_attribute": "value",
     },
     "location": {
-        "signature": {
-            "display_name": "Macclesfield, Cheshire",
-            "attributes": {
-                "director": "John Smith",
-            },
+        "selector": {
+            "display_name",
+            "attributes.director",
         },
+        "display_name": "Macclesfield, Cheshire",
         "description": "Manufacturing site, North West England, Macclesfield, Cheshire",
         "latitude": "53.2546799",
         "longitude": "-2.1213956,14.54",
         "attributes": {
+            "director": "John Smith",
             "address": "Bridgewater, Somerset",
             "facility_type": "Manufacture",
             "support_email": "support@macclesfield.com",

--- a/unittests/testassetsconstants.py
+++ b/unittests/testassetsconstants.py
@@ -152,8 +152,12 @@ RESPONSE = {
 # case 2 create if not exists
 REQUEST_EXISTS = {
     "selector": [
-        "attributes.arc_display_name",
-        "attributes.arc_namespace",
+        {
+            "attributes": [
+                "arc_display_name",
+                "arc_namespace",
+            ]
+        },
     ],
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -205,8 +209,12 @@ RESPONSE_EXISTS = {
 # case 3 create if not exists with attachments
 REQUEST_EXISTS_ATTACHMENTS = {
     "selector": [
-        "attributes.arc_display_name",
-        "attributes.arc_namespace",
+        {
+            "attributes": [
+                "arc_display_name",
+                "arc_namespace",
+            ]
+        },
     ],
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -292,8 +300,12 @@ RESPONSE_EXISTS_ATTACHMENTS = {
 # case 4 create if not exists with location
 REQUEST_EXISTS_LOCATION = {
     "selector": [
-        "attributes.arc_display_name",
-        "attributes.arc_namespace",
+        {
+            "attributes": [
+                "arc_display_name",
+                "arc_namespace",
+            ]
+        },
     ],
     "behaviours": BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -307,10 +319,14 @@ REQUEST_EXISTS_LOCATION = {
         "some_custom_attribute": "value",
     },
     "location": {
-        "selector": {
+        "selector": [
             "display_name",
-            "attributes.director",
-        },
+            {
+                "attributes": [
+                    "director",
+                ]
+            },
+        ],
         "display_name": "Macclesfield, Cheshire",
         "description": "Manufacturing site, North West England, Macclesfield, Cheshire",
         "latitude": "53.2546799",

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -83,16 +83,32 @@ RESPONSE = {
     },
 }
 REQUEST_EXISTS = {
-    "signature": {
-        "display_name": "Macclesfield, Cheshire",
-        "attributes": {
-            "director": "John Smith",
-        },
-    },
+    "selector": [
+        "display_name",
+        "attributes.director",
+    ],
+    "display_name": "Macclesfield, Cheshire",
     "description": "Manufacturing site, North West England, Macclesfield, Cheshire",
     "latitude": "53.2546799",
     "longitude": "-2.1213956,14.54",
     "attributes": {
+        "director": "John Smith",
+        "address": "Bridgewater, Somerset",
+        "facility_type": "Manufacture",
+        "support_email": "support@macclesfield.com",
+        "support_phone": "123 456 789",
+    },
+}
+REQUEST_EXISTS_SELECTOR_NOATTRS = {
+    "selector": [
+        "display_name",
+    ],
+    "display_name": "Macclesfield, Cheshire",
+    "description": "Manufacturing site, North West England, Macclesfield, Cheshire",
+    "latitude": "53.2546799",
+    "longitude": "-2.1213956,14.54",
+    "attributes": {
+        "director": "John Smith",
         "address": "Bridgewater, Somerset",
         "facility_type": "Manufacture",
         "support_email": "support@macclesfield.com",
@@ -211,6 +227,50 @@ class TestLocations(TestCase):
             mock_post.return_value = MockResponse(200, **RESPONSE)
             location, existed = self.arch.locations.create_if_not_exists(
                 REQUEST_EXISTS,
+            )
+            mock_get.assert_called_once()
+            mock_post.assert_called_once()
+            self.assertEqual(
+                location,
+                RESPONSE,
+                msg="Incorrect location listed",
+            )
+            self.assertEqual(
+                existed,
+                False,
+                msg="Incorrect existed bool",
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                args,
+                (f"url/{ROOT}/{SUBPATH}",),
+                msg="CREATE method args called incorrectly",
+            )
+            self.assertEqual(
+                kwargs,
+                {
+                    "json": REQUEST,
+                    "headers": {
+                        "authorization": "Bearer authauthauth",
+                    },
+                    "verify": True,
+                },
+                msg="CREATE method kwargs called incorrectly",
+            )
+
+    def test_locations_create_if_not_exists_nonexistent_location_selector_noattributes(
+        self,
+    ):
+        """
+        Test location creation
+        """
+        with mock.patch.object(
+            self.arch._session, "get"
+        ) as mock_get, mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_get.side_effect = ArchivistNotFoundError
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            location, existed = self.arch.locations.create_if_not_exists(
+                REQUEST_EXISTS_SELECTOR_NOATTRS,
             )
             mock_get.assert_called_once()
             mock_post.assert_called_once()

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -85,7 +85,11 @@ RESPONSE = {
 REQUEST_EXISTS = {
     "selector": [
         "display_name",
-        "attributes.director",
+        {
+            "attributes": [
+                "director",
+            ],
+        },
     ],
     "display_name": "Macclesfield, Cheshire",
     "description": "Manufacturing site, North West England, Macclesfield, Cheshire",

--- a/unittests/testrunner.py
+++ b/unittests/testrunner.py
@@ -168,7 +168,7 @@ class TestRunner(TestCase):
         """
         runner = self.arch.runner
         runner.entities = tree()
-        runner.set_entities(Asset(**ASSETS_RESPONSE))
+        runner.set_entities(ASSET_NAME, Asset(**ASSETS_RESPONSE))
         self.assertEqual(
             runner.asset_id(ASSET_NAME),
             ASSET_ID,

--- a/unittests/testrunnerassets.py
+++ b/unittests/testrunnerassets.py
@@ -39,13 +39,12 @@ ASSETS_CREATE = {
     **ASSETS_CREATE_ARGS,
 }
 ASSETS_CREATE_IF_NOT_EXISTS = {
-    "signature": {
-        "attributes": {
-            "arc_display_name": ASSET_NAME,
-        },
+    "selector": {
+        "attributes.arc_display_name",
     },
     "behaviours": ["RecordEvidence", "Attachments"],
     "attributes": {
+        "arc_display_name": ASSET_NAME,
         "radioactive": True,
         "radiation_level": 0,
         "weight": 0,
@@ -172,6 +171,7 @@ class TestRunnerAssetsCreate(TestCase):
                                 "action": "ASSETS_CREATE",
                                 "wait_time": 10,
                                 "description": "Testing runner assets create",
+                                "asset_label": "Existing Asset",
                                 "delete": True,
                             },
                             **ASSETS_CREATE,
@@ -179,13 +179,13 @@ class TestRunnerAssetsCreate(TestCase):
                     ],
                 }
             )
-            mock_sleep.assert_called_once_with(10)
             mock_assets_create.assert_called_once_with(ASSETS_CREATE_ARGS)
             self.assertEqual(
-                self.arch.runner.entities[ASSET_NAME],
+                self.arch.runner.entities["Existing Asset"],
                 ASSETS_RESPONSE,
                 msg="Incorrect asset created",
             )
+            mock_sleep.assert_called_once_with(10)
 
     @mock.patch("archivist.runner.time_sleep")
     def test_runner_assets_create_if_not_exists(self, mock_sleep):
@@ -204,6 +204,7 @@ class TestRunnerAssetsCreate(TestCase):
                                 "action": "ASSETS_CREATE_IF_NOT_EXISTS",
                                 "wait_time": 10,
                                 "description": "Testing runner assets create if not exists",
+                                "asset_label": "Existing Asset",
                             },
                             **ASSETS_CREATE_IF_NOT_EXISTS,
                             "confirm": True,
@@ -211,15 +212,15 @@ class TestRunnerAssetsCreate(TestCase):
                     ],
                 }
             )
-            mock_sleep.assert_called_once_with(10)
             mock_assets_create.assert_called_once_with(
                 ASSETS_CREATE_IF_NOT_EXISTS, **ASSETS_CONFIRM
             )
             self.assertEqual(
-                self.arch.runner.entities[ASSET_NAME],
+                self.arch.runner.entities["Existing Asset"],
                 ASSETS_RESPONSE,
                 msg="Incorrect asset created",
             )
+            mock_sleep.assert_called_once_with(10)
 
     @mock.patch("archivist.runner.time_sleep")
     def test_runner_events_list(self, mock_sleep):
@@ -242,7 +243,7 @@ class TestRunnerAssetsCreate(TestCase):
                                 "wait_time": 10,
                                 "print_response": True,
                                 "description": "Testing runner events list",
-                                "asset_name": "Existing Asset",
+                                "asset_label": "Existing Asset",
                             },
                             **EVENTS_LIST,
                         },
@@ -309,7 +310,7 @@ class TestRunnerAssetsCreate(TestCase):
 
             self.assertEqual("Missing Action" in str(ex.exception), True)
 
-    def test_runner_assets_create_illegal_asset_name(self):
+    def test_runner_assets_create_illegal_asset_label(self):
         """
         Test runner operation
         """
@@ -325,7 +326,7 @@ class TestRunnerAssetsCreate(TestCase):
                                 "step": {
                                     "action": "EVENTS_CREATE",
                                     "wait_time": 10,
-                                    "asset_name": "Nonexistent asset",
+                                    "asset_label": "Nonexistent asset",
                                 },
                                 **ASSETS_CREATE,
                             }
@@ -333,7 +334,7 @@ class TestRunnerAssetsCreate(TestCase):
                     }
                 )
 
-            self.assertEqual("Unknown Asset" in str(ex.exception), True)
+            self.assertEqual("Unknown Entity" in str(ex.exception), True)
 
     def test_runner_assets_create_invalid_action(self):
         """

--- a/unittests/testrunnercompliance.py
+++ b/unittests/testrunnercompliance.py
@@ -143,11 +143,6 @@ class TestRunnerCompliance(TestCase):
                 COMPLIANCE_POLICIES_CREATE
             )
             self.assertEqual(
-                self.arch.runner.entities[COMPLIANCE_POLICY_NAME],
-                COMPLIANCE_POLICIES_RESPONSE,
-                msg="Incorrect compliance_policy created",
-            )
-            self.assertEqual(
                 self.arch.runner.deletions[IDENTITY],
                 self.arch.compliance_policies.delete,
                 msg="Incorrect compliance_policy delete_method",
@@ -176,7 +171,7 @@ class TestRunnerCompliance(TestCase):
                                 "action": "COMPLIANCE_COMPLIANT_AT",
                                 "description": "Testing compliance_compliant_at",
                                 "print_response": True,
-                                "asset_name": COMPLIANCE_COMPLIANT_AT_NAME,
+                                "asset_label": COMPLIANCE_COMPLIANT_AT_NAME,
                             },
                         }
                     ],
@@ -218,7 +213,7 @@ class TestRunnerCompliance(TestCase):
                                 "action": "COMPLIANCE_COMPLIANT_AT",
                                 "description": "Testing compliance_compliant_at",
                                 "print_response": True,
-                                "asset_name": COMPLIANCE_COMPLIANT_AT_NAME,
+                                "asset_label": COMPLIANCE_COMPLIANT_AT_NAME,
                             },
                             "report": True,
                         }

--- a/unittests/testrunnerstep.py
+++ b/unittests/testrunnerstep.py
@@ -32,7 +32,7 @@ class TestRunnerStep(TestCase):
     maxDiff = None
 
     @staticmethod
-    def asset_id_method(unused_asset_name):
+    def asset_id_method(unused_label):
         return ASSET_ID
 
     def setUp(self):
@@ -49,7 +49,7 @@ class TestRunnerStep(TestCase):
                 "wait_time": 10,
                 "print_response": True,
                 "description": "Testing runner events list",
-                "asset_name": "Existing Asset",
+                "asset_label": "Existing Asset",
                 "delete": True,
             }
         )
@@ -88,7 +88,7 @@ class TestRunnerStep(TestCase):
                 "wait_time": 10,
                 "print_response": True,
                 "description": "Testing runner events list",
-                "asset_name": "Existing Asset",
+                "asset_label": "Existing Asset",
                 "delete": True,
             }
         )
@@ -138,4 +138,28 @@ class TestRunnerStep(TestCase):
             step.kwargs(self.asset_id_method, {}),
             {"asset_id": ASSET_ID},
             msg="Incorrect kwargs",
+        )
+
+        self.assertEqual(
+            step.set_asset_id,
+            False,
+            msg="Incorrect set_asset_id",
+        )
+        # a second time to prove memoization is working.
+        self.assertEqual(
+            step.set_asset_id,
+            False,
+            msg="Incorrect set_asset_id",
+        )
+
+        self.assertEqual(
+            step.use_asset_id,
+            True,
+            msg="Incorrect use_asset_id",
+        )
+        # a second time to prove memoization is working.
+        self.assertEqual(
+            step.use_asset_id,
+            True,
+            msg="Incorrect use_asset_id",
         )


### PR DESCRIPTION
Problem:
The use of an asset or location signature was considered a
inferior design. Use a selector instead where one can specify
which attributes signify a unique asset/location.

Solution:
Changed create_of_not_exists() of both assets and locations to
use a selector. Modified door_entry story.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>