### PR TITLE
SBOM file might not have uuid

### DIFF
--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -116,9 +116,13 @@ class _SBOMSClient:
             "author": c["author"],
             "component": c["name"],
             "supplier": c["supplier"]["name"],
-            "uuid": b["@serialNumber"],
             "version": c["version"],
         }
+
+        uuid = b.get("@serialNumber")
+        if uuid is not None:
+            result["uuid"] = uuid
+
         try:
             hash_value = c["hashes"]["hash"]["#text"]
         except (TypeError, KeyError):


### PR DESCRIPTION
Problem:
Uploading a an SBOM as an attachment may not have
a uuid field

Solution:
Do not create uuid value if it does not exist in SBOM.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>