### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,9 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         ./scripts/version.sh
-        python setup.py sdist bdist_wheel
+        python3 -m build --sdist
+        python3 -m build --wheel
+        twine check dist/*
         twine upload dist/*
     - name: Build docs
       uses: ammaraskar/sphinx-action@master

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.xml
 .cache/
 .eggs/
 .task/
+.pip-audit-cache/
 *.pyi
 .vscode
 stuntidp*

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -168,9 +168,9 @@ FUNCTEST=execrunner task functests
 
 #### Testing Other Python Versions
 
-##### Python 3.6
+##### Python 3.7 (default)
 
-To build the docker builder image with default Python version 3.6:
+To build the docker builder image with default Python 3.7:
 ```bash
 task builder
 ```
@@ -185,26 +185,9 @@ To run the unittests:
 task unittests
 ```
 
-##### Python 3.7
-
-To build the docker builder image with Python 3.7:
-```bash
-task builder-3.7
-```
-
-To check the style
-```bash
-task check
-```
-
-To run the unittests:
-```bash
-task unittests
-```
-
 ##### Python 3.8
 
-To build the docker builder image with Python 3.7:
+To build the docker builder image with Python 3.8:
 ```bash
 task builder-3.8
 ```
@@ -224,6 +207,23 @@ task unittests
 To build the docker builder image with Python 3.9:
 ```bash
 task builder-3.9
+```
+
+To check the style
+```bash
+task check
+```
+
+To run the unittests:
+```bash
+task unittests
+```
+
+##### Python 3.10
+
+To build the docker builder image with Python 3.10:
+```bash
+task builder-3.10
 ```
 
 To check the style

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,10 +1,10 @@
-ARG VERSION=3.6
-FROM python:${VERSION}-buster
+ARG VERSION=3.7
+FROM python:${VERSION}-bullseye
 
 COPY requirements.txt requirements-dev.txt /tmp/
 
-RUN python3 -m pip -qq install --upgrade pip \
-  && python3 -m pip -qq install -U -r /tmp/requirements-dev.txt \
+RUN python3 -m pip install --upgrade pip \
+  && python3 -m pip install -U -r /tmp/requirements-dev.txt \
   && rm -f /tmp/requirements-dev.txt \
   && rm -f /tmp/requirements.txt
 

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,18 @@ The standard Jitsuin Archivist python client.
 Please note that the canonical API for Jitsuin Archivist is always the REST API
 documented at https://docs.rkvst.com
 
+Support
+=======
+
+This package currently is tested against Python versions 3.7,3.8,3.9 and 3.10.
+
+The current default version is 3.7 - this means that this package will not
+use any features specific to versions 3.8 and later.
+
+After End of Life of a particular Python version, support is offered on a best effort
+basis. We may ask you to update your Python version to help solve the problem,
+if it cannot be reasonably resolved in your current version.
+
 Installation
 =============
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,11 +18,6 @@ tasks:
   builder:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
-      - docker build --no-cache --build-arg VERSION=3.6 -f Dockerfile-builder -t jitsuin-archivist-python-builder .
-
-  builder-3.7:
-    desc: Build a docker environment with the right dependencies and utilities
-    cmds:
       - docker build --no-cache --build-arg VERSION=3.7 -f Dockerfile-builder -t jitsuin-archivist-python-builder .
 
   builder-3.8:
@@ -53,6 +48,11 @@ tasks:
     cmds:
       - find -name '*,cover' -type f -delete
       - git clean -fdX
+
+  deps:
+    desc: Show dependency tree
+    cmds:
+      - ./scripts/builder.sh /bin/bash -c "pipdeptree"
 
   docs:
     desc: Create sphinx documentation

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -11,7 +11,7 @@ The definitive guide to the REST API is defined here: https://docs.rkvst.com
 This python SDK offers a number of advantages over a simple 
 REST api (in any language):
 
-    *  versioned package for the python 3.6,3.7,3.8,3.9,3.10 ecosystem.
+    *  versioned package for the python 3.7,3.8,3.9,3.10 ecosystem.
     *  automatic confirmation of assets and events: just set **confirm=True** when
        creating the asset or event and a sophisticated retry and exponential backoff
        algorithm will take care of everything.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,18 +3,18 @@
 #
 # Duplicate of stanza in ~/requirements-dev.txt.
 # Make changes in both places
-sphinx~=4.3
-sphinx-rtd-theme~=1.0.0
+sphinx~=4.4
+sphinx-rtd-theme~=1.0
 
 # Duplicate of stanza in ~/requirements.txt.
 # Make changes in both places
 backoff~=1.11
 certifi
-flatten-dict~=0.3
-iso8601~=0.1
+flatten-dict~=0.4
+iso8601~=1.0
 Jinja2~=3.0
 pyaml-env~=1.1
-requests~=2.22
+requests~=2.27
 requests-toolbelt~=0.9
 rfc3339~=6.2
 xmltodict~=0.12.0

--- a/functests/__init__.py
+++ b/functests/__init__.py
@@ -1,3 +1,7 @@
 """
 functional tests
 """
+import unittest
+
+# Hides Docstring
+unittest.TestCase.shortDescription = lambda x: None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,18 +1,22 @@
 -r requirements.txt
 
 # code quality
-autopep8~=1.5
+autopep8~=1.6
 black~=22.3
-coverage~=6.2
-pip-audit~=1.0.0
-pycodestyle~=2.6
-pylint~=2.6
+coverage~=6.3
+pip-audit~=2.0
+pycodestyle~=2.8
+pylint~=2.12
 
 # uploading to pypi
-twine~=3.4
+build~=0.7.0
+twine~=3.8
 
 # documentation
 # the file docs/requirements.txt
 # must be kept in sync with this file.
-sphinx~=4.3
-sphinx-rtd-theme~=1.0.0
+sphinx~=4.4
+sphinx-rtd-theme~=1.0
+
+# analyze dependencies
+pipdeptree~=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 backoff~=1.11
 certifi
-flatten-dict~=0.3
-iso8601~=0.1
+flatten-dict~=0.4
+iso8601~=1.0
 Jinja2~=3.0
 pyaml-env~=1.1
-requests~=2.22
+requests~=2.27
 requests-toolbelt~=0.9
 rfc3339~=6.2
 xmltodict~=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",  # MIT
         "Operating System :: POSIX :: Linux",  # https://pypi.org/classifiers/ # on anything
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Utilities",  # https://pypi.org/classifiers/ # check another option client-sdk
     ],
     install_requires=requirements,
@@ -45,7 +45,7 @@ setup(
         "count_commits_from_version_file": False,
     },
     setup_requires=["setuptools-git-versioning==1.7.4"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={
         "console_scripts": [
             "archivist_runner = archivist.cmds.runner.main:main",

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -1,3 +1,7 @@
 """
 Unit tests
 """
+import unittest
+
+# Hides Docstring
+unittest.TestCase.shortDescription = lambda x: None


### PR DESCRIPTION
Problem:
Python 3.6 is EOL December 2021. Additionally we are unable
to use an increasing number of dependencies as they withdraw
support for 3.6. Subsequent work involving using swagger
json definitions to generate dataclasses is restricted to
3.7 and later.

Solution:
Remove all support for Python 3.6 and default to 3.7. Improve
the github actions to check integrity of wheel. Fix restructuted
text of README for PyPi.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>