### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 .task/
 *.pyi
 .vscode
+stuntidp*

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email="support@jitsuin.com",
     description="Jitsuin Archivist Client",
     long_description=DESC,
-    long_description_content_type="text/markdown",
+    long_description_content_type="text/x-rst",
     url=REPO_URL,
     packages=find_packages(exclude=("examples", "unittests", "functests")),
     platforms=["any"],


### PR DESCRIPTION
Problem:
incorrect README type and ignore secrets files

Solution:
Change content type in setup.py and added stuntidp files
to gitignore.

Signed-off-by: Paul Hewlett <phewlstt76@gmail.com>