### PR TITLE
Read secrets from environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -133,14 +133,32 @@ NOTE: For the access policy functional tests, two separate tenancy tokens are ne
 export TEST_AUTHTOKEN_FILENAME_2=credentials/authtoken_tenant_2
 ```
 
+Alternatively one can use a direct environment variable for the authtoken:
+```bash
+export TEST_AUTHTOKEN_FILENAME=
+export TEST_AUTHTOKEN="ey.....==="
+task functests
+```
+
 Alternatively one can use a client id and secret obtained from the appregistrations endpoint:
 ```bash
 export TEST_AUTHTOKEN_FILENAME=
+export TEST_AUTHTOKEN=
 export TEST_CLIENT_ID=c5db8230-6e1c-4b80-9481-d70e647c0429
 export TEST_CLIENT_SECRET_FILENAME=credentials/client_secret
 task functests
 ```
 
+Additionally one set the appregistration directly in the environment:
+
+```bash
+export TEST_AUTHTOKEN_FILENAME=
+export TEST_AUTHTOKEN=
+export TEST_CLIENT_ID=c5db8230-6e1c-4b80-9481-d70e647c0429
+export TEST_CLIENT_SECRET_FILENAME=
+export TEST_CLIENT_SECRET="ey.....................ab=="
+task functests
+```
 Lastly when running the runner tests one can specify a namespace to isolate instances of assets in differnt 
 runs:
 ```bash

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -86,10 +86,17 @@ def common_parser(description: str):
         help="mechanism for proving the evidence for events on the Asset",
     )
     parser.add_argument(
-        "-t",
         "--auth-token",
         type=str,
-        dest="auth_token_file",
+        dest="auth_token",
+        action="store",
+        default=None,
+        help="API token value",
+    )
+    parser.add_argument(
+        "--auth-token-filename",
+        type=str,
+        dest="auth_token_filename",
         action="store",
         default=None,
         help="FILE containing API authentication token",
@@ -105,7 +112,15 @@ def common_parser(description: str):
     parser.add_argument(
         "--client-secret",
         type=str,
-        dest="client_secret_file",
+        dest="client_secret",
+        action="store",
+        default=None,
+        help="Client secret from appregistrations",
+    )
+    parser.add_argument(
+        "--client-secret-filename",
+        type=str,
+        dest="client_secret_filename",
         action="store",
         default=None,
         help="FILE containing client secret from appregistrations",
@@ -158,9 +173,11 @@ def endpoint(args):
         )
 
     auth = get_auth(
-        auth_token_filename=args.auth_token_file,
+        auth_token=args.auth_token,
+        auth_token_filename=args.auth_token_filename,
         client_id=args.client_id,
-        client_secret_filename=args.client_secret_file,
+        client_secret=args.client_secret,
+        client_secret_filename=args.client_secret_filename,
     )
 
     if auth is None:

--- a/archivist/utils.py
+++ b/archivist/utils.py
@@ -53,22 +53,34 @@ def get_url(url: str, fd: BytesIO):  # pragma no cover
 
 
 def get_auth(
-    *, auth_token_filename=None, client_id=None, client_secret_filename=None
+    *,
+    auth_token_filename=None,
+    auth_token=None,
+    client_id=None,
+    client_secret_filename=None,
+    client_secret=None,
 ):  # pragma no cover
     """
     Return auth as either stuntidp token or client_id,client_secret tuple
     """
+
+    if auth_token:
+        return auth_token
+
     if auth_token_filename:
         with open(auth_token_filename, mode="r", encoding="utf-8") as tokenfile:
-            authtoken = tokenfile.read().strip()
+            auth_token = tokenfile.read().strip()
 
-        return authtoken
+        return auth_token
 
-    if client_id is not None and client_secret_filename is not None:
-        with open(client_secret_filename, mode="r", encoding="utf-8") as tokenfile:
-            authtoken = tokenfile.read().strip()
+    if client_id is not None:
+        if client_secret_filename is not None:
+            with open(client_secret_filename, mode="r", encoding="utf-8") as tokenfile:
+                client_secret = tokenfile.read().strip()
+            return (client_id, client_secret)
 
-        return (client_id, authtoken)
+        if client_secret is not None:
+            return (client_id, client_secret)
 
     return None
 

--- a/docs/runner/execute.rst
+++ b/docs/runner/execute.rst
@@ -9,6 +9,6 @@ A straightforward incantation of the yaml runner:
 
    $ archivist_runner \
          -u https://app.rkvst.io \
-         -t credentials/token \
+         --auth-token-filename credentials/token \
          functests/test_resources/richness_story.yaml
 

--- a/docs/runner/index.rst
+++ b/docs/runner/index.rst
@@ -31,7 +31,7 @@ Execute:
 
    $ archivist_runner \
          -u https://app.rkvst.io \
-         -t credentials/token \
+         --auth-token-filename credentials/token \
          functests/test_resources/richness_story.yaml
 
 For more flexibility the functionality can be extended.

--- a/examples/access_policies_filter.py
+++ b/examples/access_policies_filter.py
@@ -23,8 +23,10 @@ def main():
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     auth = get_auth(
+        auth_token=getenv("ARCHIVIST_AUTHTOKEN"),
         auth_token_filename=getenv("ARCHIVIST_AUTHTOKEN_FILENAME"),
         client_id=getenv("ARCHIVIST_CLIENT_ID"),
+        client_secret=getenv("ARCHIVIST_CLIENT_SECRET"),
         client_secret_filename=getenv("ARCHIVIST_CLIENT_SECRET_FILENAME"),
     )
 

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -82,8 +82,10 @@ def main():
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     auth = get_auth(
+        auth_token=getenv("ARCHIVIST_AUTHTOKEN"),
         auth_token_filename=getenv("ARCHIVIST_AUTHTOKEN_FILENAME"),
         client_id=getenv("ARCHIVIST_CLIENT_ID"),
+        client_secret=getenv("ARCHIVIST_CLIENT_SECRET"),
         client_secret_filename=getenv("ARCHIVIST_CLIENT_SECRET_FILENAME"),
     )
 

--- a/examples/sbom_release.py
+++ b/examples/sbom_release.py
@@ -92,8 +92,10 @@ def main():
     rkvst_url = getenv("RKVST_URL")
 
     auth = get_auth(
+        auth_token=getenv("AUTHTOKEN"),
         auth_token_filename=getenv("AUTHTOKEN_FILENAME"),
         client_id=getenv("CLIENT_ID"),
+        client_secret=getenv("CLIENT_SECRET"),
         client_secret_filename=getenv("CLIENT_SECRET_FILENAME"),
     )
 

--- a/examples/scan_test.py
+++ b/examples/scan_test.py
@@ -128,8 +128,10 @@ def main():
     main entry point
     """
     auth = get_auth(
+        auth_token=getenv("TEST_AUTHTOKEN"),
         auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
         client_id=getenv("TEST_CLIENT_ID"),
+        client_secret=getenv("TEST_CLIENT_SECRET"),
         client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
     )
 

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -64,8 +64,10 @@ class TestAccessPoliciesBase(TestCase):
 
     def setUp(self):
         auth = get_auth(
+            auth_token=getenv("TEST_AUTHTOKEN"),
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -44,8 +44,10 @@ class TestApplications(TestCase):
 
     def setUp(self):
         auth = get_auth(
+            auth_token=getenv("TEST_AUTHTOKEN"),
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -72,8 +72,10 @@ class TestAssetCreate(TestCase):
 
     def setUp(self):
         auth = get_auth(
+            auth_token=getenv("TEST_AUTHTOKEN"),
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(
@@ -231,8 +233,10 @@ class TestAssetCreateIfNotExists(TestCase):
 
     def setUp(self):
         auth = get_auth(
+            auth_token=getenv("TEST_AUTHTOKEN"),
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -34,8 +34,10 @@ class TestAttachmentstCreate(TestCase):
 
     def setUp(self):
         auth = get_auth(
+            auth_token=getenv("TEST_AUTHTOKEN"),
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -37,6 +37,7 @@ class TestRunner(TestCase):
         auth = get_auth(
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(

--- a/functests/execsboms.py
+++ b/functests/execsboms.py
@@ -42,8 +42,10 @@ class TestSBOM(TestCase):
 
     def setUp(self):
         auth = get_auth(
+            auth_token=getenv("TEST_AUTHTOKEN"),
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -59,6 +59,7 @@ class TestSubjects(TestCase):
         auth = get_auth(
             auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
             client_id=getenv("TEST_CLIENT_ID"),
+            client_secret=getenv("TEST_CLIENT_SECRET"),
             client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
         )
         self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -15,9 +15,11 @@ docker run \
     -e UNITTEST \
     -e ARCHIVIST_NAMESPACE \
     -e TEST_ARCHIVIST \
+    -e TEST_AUTHTOKEN \
     -e TEST_AUTHTOKEN_FILENAME \
     -e TEST_AUTHTOKEN_FILENAME_2 \
     -e TEST_CLIENT_ID \
+    -e TEST_CLIENT_SECRET \
     -e TEST_CLIENT_SECRET_FILENAME \
     -e TEST_DEBUG \
     jitsuin-archivist-python-builder \

--- a/scripts/functests.sh
+++ b/scripts/functests.sh
@@ -9,25 +9,31 @@ then
 fi
 if [ -n "${TEST_CLIENT_ID}" ]
 then
-    if [ -z "${TEST_CLIENT_SECRET_FILENAME}" ]
+    if [ -n "${TEST_CLIENT_SECRET_FILENAME}" ]
     then
-        echo "TEST_CLIENT_SECRET_FILENAME is undefined"
-        exit 1
-    fi
-    if [ ! -s "${TEST_CLIENT_SECRET_FILENAME}" ]
+        if [ ! -s "${TEST_CLIENT_SECRET_FILENAME}" ]
+        then
+            echo "${TEST_CLIENT_SECRET_FILENAME} does not exist"
+            exit 1
+        fi
+    elif [ -z "${TEST_CLIENT_SECRET}" ]
     then
-        echo "${TEST_CLIENT_SECRET_FILENAME} does not exist"
+        echo "Both TEST_CLIENT_SECRET_FILENAME"
+        echo "and TEST_CLIENT_SECRET are undefined"
         exit 1
     fi
 else
-    if [ -z "${TEST_AUTHTOKEN_FILENAME}" ]
+    if [ -n "${TEST_AUTHTOKEN_FILENAME}" ]
     then
-        echo "TEST_AUTHTOKEN_FILENAME is undefined"
-        exit 1
-    fi
-    if [ ! -s "${TEST_AUTHTOKEN_FILENAME}" ]
+        if [ ! -s "${TEST_AUTHTOKEN_FILENAME}" ]
+        then
+            echo "${TEST_AUTHTOKEN_FILENAME} does not exist"
+            exit 1
+        fi
+    elif [ -z "${TEST_AUTHTOKEN}" ]
     then
-        echo "${TEST_AUTHTOKEN_FILENAME} does not exist"
+        echo "Both TEST_AUTHTOKEN_FILENAME"
+        echo "and TEST_AUTHTOKEN are undefined"
         exit 1
     fi
 fi


### PR DESCRIPTION
Problem:
Currently secrets are expected to reside in a file in a
protected directory. This is not optimal in pipelines
and other environments.

Solution:
Allow specifying a secret set in an environment variable
directly.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>