### PR TITLE
Build package is missing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install setuptools wheel twine
+        python3 -m pip install build setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
Problem:
Releaae process requires build module which
mysteriously disappeared from 3.10

Solution:
Explicitly install build package

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>