### PR TITLE
Fixing Subjects YAML Formatting

### DIFF
--- a/docs/runner/events_list.rst
+++ b/docs/runner/events_list.rst
@@ -9,7 +9,7 @@ for which the authorised Application Registration has Event write access
 
 If :code:`asset_label` is not set, data for all assets is output.
 
-:code:`props`, :code:`attrs` and :code:`asset_attrs`` are optional.
+:code:`props`, :code:`attrs` and :code:`asset_attrs` are optional.
 
 This example lists all 'open door' events for the Courts of Justice Front Door.
 

--- a/docs/runner/subjects_count.rst
+++ b/docs/runner/subjects_count.rst
@@ -5,9 +5,9 @@ Subjects Count Story Runner YAML
 
 Count all subjects that have the required signature.
 
-The display_name is optional.
+The :code:`display_name` is optional.
 
-The 'print_response' setting should be specified as True in order to see the results.
+The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
 .. code-block:: yaml
     

--- a/docs/runner/subjects_create.rst
+++ b/docs/runner/subjects_create.rst
@@ -3,7 +3,7 @@
 Subjects Create Story Runner YAML
 .........................................
 
-'subject_label' is not required but if unspecified the created subject will
+:code:`subject_label` is not required but if unspecified the created subject will
 not be accessible to later actions in the story.
 
 .. code-block:: yaml
@@ -11,12 +11,12 @@ not be accessible to later actions in the story.
     ---
     steps:
       - step:
-        action: SUBJECTS_CREATE
-        description: Create a subjects entity.
-        print_response: true
-        subject_label: A subject
-      display_name: A subject
-      wallet_pub_keys:
-        - wallet_pub_key1
-      tessera_pub_keys:
-        - tessera_pub_key2
+          action: SUBJECTS_CREATE
+          description: Create a subjects entity.
+          print_response: true
+          subject_label: A subject
+        display_name: A subject
+        wallet_pub_keys:
+          - wallet_pub_key1
+        tessera_pub_keys:
+          - tessera_pub_key2

--- a/docs/runner/subjects_create_b64.rst
+++ b/docs/runner/subjects_create_b64.rst
@@ -3,7 +3,7 @@
 Subjects Create From base64 Story Runner YAML
 .............................................
 
-'subject_label' is not required but if unspecified the created subject will
+:code:`subject_label` is not required but if unspecified the created subject will
 not be accessible to later actions in the story.
 
 .. code-block:: yaml
@@ -11,20 +11,21 @@ not be accessible to later actions in the story.
     ---
     steps:
       - step:
-        action: SUBJECTS_CREATE_FROM_B64
-        description: Import a subjects entity.
-        print_response: true
-        subject_label: An imported subject
-      display_name: An imported subject
-      subject_string: eyJpZGVudGl0eSI6ICJzdWJqZWN0cy8wMDAwMDAwMC0wMDAwLTAwMDAtMDA
-                      wMC0wMDAwMDAwMDAwMDAiLCAiZGlzcGxheV9uYW1lIjogIlNlbGYiLCAid2
-                      FsbGV0X3B1Yl9rZXkiOiBbIjA0YzExNzNiZjc4NDRiZjFjNjA3Yjc5YzE4Z
-                      GIwOTFiOTU1OGZmZTU4MWJmMTMyYjhjZjNiMzc2NTcyMzBmYTMyMWEwODgw
-                      YjU0YTc5YTg4YjI4YmM3MTBlZGU2ZGNmM2Q4MjcyYzUyMTBiZmQ0MWVhODM
-                      xODhlMzg1ZDEyYzE4OWMiXSwgIndhbGxldF9hZGRyZXNzIjogWyIweDk5Rm
-                      E0QUFCMEFGMkI1M2YxNTgwODNEOGYyNDRiYjQ1MjMzODgxOTciXSwgInRlc
-                      3NlcmFfcHViX2tleSI6IFsiZWZkZzlKMFFoU0IyZzRJeEtjYVhnSm1OS2J6
-                      cHhzMDNGRllJaVlZdWVraz0iXSwgInRlbmFudCI6ICIiLCAiY29uZmlybWF
-                      0aW9uX3N0YXR1cyI6ICJDT05GSVJNQVRJT05fU1RBVFVTX1VOU1BFQ0lGSU
-                      VEIn0=
+          action: SUBJECTS_CREATE_FROM_B64
+          description: Import a subjects entity.
+          print_response: true
+          subject_label: An imported subject
+        display_name: An imported subject
+        subject_string: >-
+          eyJpZGVudGl0eSI6ICJzdWJqZWN0cy8wMDAwMDAwMC0wMDAwLTAwMDAtMDA
+          wMC0wMDAwMDAwMDAwMDAiLCAiZGlzcGxheV9uYW1lIjogIlNlbGYiLCAid2
+          FsbGV0X3B1Yl9rZXkiOiBbIjA0YzExNzNiZjc4NDRiZjFjNjA3Yjc5YzE4Z
+          GIwOTFiOTU1OGZmZTU4MWJmMTMyYjhjZjNiMzc2NTcyMzBmYTMyMWEwODgw
+          YjU0YTc5YTg4YjI4YmM3MTBlZGU2ZGNmM2Q4MjcyYzUyMTBiZmQ0MWVhODM
+          xODhlMzg1ZDEyYzE4OWMiXSwgIndhbGxldF9hZGRyZXNzIjogWyIweDk5Rm
+          E0QUFCMEFGMkI1M2YxNTgwODNEOGYyNDRiYjQ1MjMzODgxOTciXSwgInRlc
+          3NlcmFfcHViX2tleSI6IFsiZWZkZzlKMFFoU0IyZzRJeEtjYVhnSm1OS2J6
+          cHhzMDNGRllJaVlZdWVraz0iXSwgInRlbmFudCI6ICIiLCAiY29uZmlybWF
+          0aW9uX3N0YXR1cyI6ICJDT05GSVJNQVRJT05fU1RBVFVTX1VOU1BFQ0lGSU
+          VEIn0=
 

--- a/docs/runner/subjects_list.rst
+++ b/docs/runner/subjects_list.rst
@@ -5,7 +5,7 @@ Subjects List Story Runner YAML
 
 List all subjects that have the required signature.
 
-The 'print_response' setting should be specified as True in order to see the results.
+The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
 .. code-block:: yaml
     

--- a/docs/runner/subjects_read.rst
+++ b/docs/runner/subjects_read.rst
@@ -5,9 +5,9 @@ Subjects Read Story Runner YAML
 
 Read the specified subject.
 
-'subject_label' is required.
+:code:`subject_label` is required.
 
-The 'print_response' setting should be specified as True in order to see the results.
+The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
 .. code-block:: yaml
     

--- a/docs/runner/subjects_update.rst
+++ b/docs/runner/subjects_update.rst
@@ -13,14 +13,14 @@ optional but at least one must be specified.
     ---
     steps:
       - step:
-        action: SUBJECTS_UPDATE
-        description: Update a subjects entity.
-        print_response: true
-        subject_label: A subject
-      display_name: A subject
-      wallet_pub_keys:
-        - wallet_pub_key1
-        - wallet_pub_key2
-      tessera_pub_keys:
-        - tessera_pub_key1
-        - tessera_pub_key2
+          action: SUBJECTS_UPDATE
+          description: Update a subjects entity.
+          print_response: true
+          subject_label: A subject
+        display_name: A subject
+        wallet_pub_keys:
+          - wallet_pub_key1
+          - wallet_pub_key2
+        tessera_pub_keys:
+          - tessera_pub_key1
+          - tessera_pub_key2

--- a/functests/test_resources/subjects_story.yaml
+++ b/functests/test_resources/subjects_story.yaml
@@ -17,17 +17,18 @@ steps:
       print_response: true
       subject_label: An imported subject
     display_name: An imported subject
-    subject_string: eyJpZGVudGl0eSI6ICJzdWJqZWN0cy8wMDAwMDAwMC0wMDAwLTAwMDAtMDA
-                    wMC0wMDAwMDAwMDAwMDAiLCAiZGlzcGxheV9uYW1lIjogIlNlbGYiLCAid2
-                    FsbGV0X3B1Yl9rZXkiOiBbIjA0YzExNzNiZjc4NDRiZjFjNjA3Yjc5YzE4Z
-                    GIwOTFiOTU1OGZmZTU4MWJmMTMyYjhjZjNiMzc2NTcyMzBmYTMyMWEwODgw
-                    YjU0YTc5YTg4YjI4YmM3MTBlZGU2ZGNmM2Q4MjcyYzUyMTBiZmQ0MWVhODM
-                    xODhlMzg1ZDEyYzE4OWMiXSwgIndhbGxldF9hZGRyZXNzIjogWyIweDk5Rm
-                    E0QUFCMEFGMkI1M2YxNTgwODNEOGYyNDRiYjQ1MjMzODgxOTciXSwgInRlc
-                    3NlcmFfcHViX2tleSI6IFsiZWZkZzlKMFFoU0IyZzRJeEtjYVhnSm1OS2J6
-                    cHhzMDNGRllJaVlZdWVraz0iXSwgInRlbmFudCI6ICIiLCAiY29uZmlybWF
-                    0aW9uX3N0YXR1cyI6ICJDT05GSVJNQVRJT05fU1RBVFVTX1VOU1BFQ0lGSU
-                    VEIn0=
+    subject_string: >-
+      eyJpZGVudGl0eSI6ICJzdWJqZWN0cy8wMDAwMDAwMC0wMDAwLTAwMDAtMDA
+      wMC0wMDAwMDAwMDAwMDAiLCAiZGlzcGxheV9uYW1lIjogIlNlbGYiLCAid2
+      FsbGV0X3B1Yl9rZXkiOiBbIjA0YzExNzNiZjc4NDRiZjFjNjA3Yjc5YzE4Z
+      GIwOTFiOTU1OGZmZTU4MWJmMTMyYjhjZjNiMzc2NTcyMzBmYTMyMWEwODgw
+      YjU0YTc5YTg4YjI4YmM3MTBlZGU2ZGNmM2Q4MjcyYzUyMTBiZmQ0MWVhODM
+      xODhlMzg1ZDEyYzE4OWMiXSwgIndhbGxldF9hZGRyZXNzIjogWyIweDk5Rm
+      E0QUFCMEFGMkI1M2YxNTgwODNEOGYyNDRiYjQ1MjMzODgxOTciXSwgInRlc
+      3NlcmFfcHViX2tleSI6IFsiZWZkZzlKMFFoU0IyZzRJeEtjYVhnSm1OS2J6
+      cHhzMDNGRllJaVlZdWVraz0iXSwgInRlbmFudCI6ICIiLCAiY29uZmlybWF
+      0aW9uX3N0YXR1cyI6ICJDT05GSVJNQVRJT05fU1RBVFVTX1VOU1BFQ0lGSU
+      VEIn0=
 
   - step:
       action: SUBJECTS_COUNT


### PR DESCRIPTION
Problem:

Subjects YAML was incorrectly indented

Solution: 

Indent Subjects YAML correctly

Also added correct Multiline YAML syntax for b64 example - https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines

Signed-off-by: Will Godfrey will.godfrey@rkvst.com

