### PR TITLE
Unittests of backoff are unreliable.

### DIFF
--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -19,6 +19,7 @@ from archivist.logger import set_logger
 from .mock_response import MockResponse
 from .testassetsconstants import (
     TestAssetsBase,
+    TestAssetsBaseConfirm,
     PRIMARY_IMAGE,
     ASSET_NAME,
     ATTRS,
@@ -139,39 +140,6 @@ class TestAssetsCreate(TestAssetsBase):
                 msg="CREATE method called incorrectly",
             )
 
-    def test_assets_create_with_confirmation(self):
-        """
-        Test asset creation
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
-            self.assertEqual(
-                asset,
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-
-    def test_assets_create_with_explicit_confirmation(self):
-        """
-        Test asset creation
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
-            self.arch.assets.wait_for_confirmation(asset["identity"])
-            self.assertEqual(
-                asset,
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-
     def test_assets_create_with_confirmation_no_confirmed_status(self):
         """
         Test asset confirmation
@@ -184,25 +152,6 @@ class TestAssetsCreate(TestAssetsBase):
 
             with self.assertRaises(ArchivistUnconfirmedError):
                 asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
-
-    def test_assets_create_with_confirmation_pending_status(self):
-        """
-        Test asset confirmation
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.side_effect = [
-                MockResponse(200, **RESPONSE_PENDING),
-                MockResponse(200, **RESPONSE),
-            ]
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
-            self.assertEqual(
-                asset,
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
 
     def test_assets_create_with_confirmation_failed_status(self):
         """
@@ -238,6 +187,64 @@ class TestAssetsCreate(TestAssetsBase):
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
                 asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+
+
+class TestAssetsCreateConfirm(TestAssetsBaseConfirm):
+    """
+    Test Archivist Assets methods with expected confirmation
+    """
+
+    def test_assets_create_with_confirmation(self):
+        """
+        Test asset creation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_assets_create_with_explicit_confirmation(self):
+        """
+        Test asset creation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
+            self.arch.assets.wait_for_confirmation(asset["identity"])
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_assets_create_with_confirmation_pending_status(self):
+        """
+        Test asset confirmation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE),
+            ]
+            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
 
 
 class TestAssetsCreateIfNotExists(TestAssetsBase):

--- a/unittests/testassetsconstants.py
+++ b/unittests/testassetsconstants.py
@@ -474,3 +474,17 @@ class TestAssetsBase(TestCase):
 
     def tearDown(self):
         self.arch = None
+
+
+class TestAssetsBaseConfirm(TestCase):
+    """
+    Test Archivist Assets Base with expected confirmation
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        self.arch = Archivist("url", "authauthauth", max_time=100)
+
+    def tearDown(self):
+        self.arch = None

--- a/unittests/testevents.py
+++ b/unittests/testevents.py
@@ -788,24 +788,6 @@ class TestEvents(TestCase):
                 msg="CREATE method called incorrectly",
             )
 
-    def test_events_create_with_confirmation(self):
-        """
-        Test event creation
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.return_value = MockResponse(200, **RESPONSE)
-
-            event = self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
-            self.assertEqual(
-                event,
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-
     def test_events_create_with_explicit_confirmation(self):
         """
         Test event creation
@@ -839,25 +821,6 @@ class TestEvents(TestCase):
                 event = self.arch.events.create(
                     ASSET_ID, PROPS, EVENT_ATTRS, confirm=True
                 )
-
-    def test_events_create_with_confirmation_pending_status(self):
-        """
-        Test asset confirmation
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.side_effect = [
-                MockResponse(200, **RESPONSE_PENDING),
-                MockResponse(200, **RESPONSE),
-            ]
-            event = self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
-            self.assertEqual(
-                event,
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
 
     def test_events_create_with_confirmation_failed_status(self):
         """
@@ -1385,4 +1348,55 @@ class TestEvents(TestCase):
                     },
                 ),
                 msg="GET method called incorrectly",
+            )
+
+
+class TestEventsConfirm(TestCase):
+    """
+    Test Archivist Events Create method with expected confirm
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        self.arch = Archivist("url", "authauthauth", max_time=100)
+
+    def tearDown(self):
+        self.arch = None
+
+    def test_events_create_with_confirmation(self):
+        """
+        Test event creation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+
+            event = self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
+            self.assertEqual(
+                event,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_events_create_with_confirmation_pending_status(self):
+        """
+        Test asset confirmation
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE_PENDING),
+                MockResponse(200, **RESPONSE),
+            ]
+            event = self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
+            self.assertEqual(
+                event,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
             )

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -160,44 +160,6 @@ class TestSBOMS(TestCase):
                 msg="UPLOAD method called incorrectly",
             )
 
-    def test_sbom_upload_with_confirmation(self):
-        """
-        Test sbom upload
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.side_effect = [
-                MockResponse(200, **RESPONSE),
-            ]
-            sbom = self.arch.sboms.upload(self.mockstream, confirm=True)
-            self.assertEqual(
-                sbom.dict(),
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-
-    def test_sbom_upload_with_confirmation_and_privacy(self):
-        """
-        Test sbom upload
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.side_effect = [
-                MockResponse(200, **RESPONSE),
-            ]
-            sbom = self.arch.sboms.upload(
-                self.mockstream, confirm=True, params={"privacy": "PUBLIC"}
-            )
-            self.assertEqual(
-                sbom.dict(),
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-
     def test_sbom_upload_with_confirmation_never_uploaded(self):
         """
         Test upload confirmation
@@ -320,22 +282,6 @@ class TestSBOMS(TestCase):
                 msg="POST method called incorrectly",
             )
 
-    def test_sbom_publish_with_confirmation(self):
-        """
-        Test sbom publication
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.return_value = MockResponse(200, **PUBLISHED_RESPONSE)
-            sbom = self.arch.sboms.publish(IDENTITY, confirm=True)
-            self.assertEqual(
-                sbom.dict(),
-                PUBLISHED_RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-
     def test_sbom_publish_with_confirmation_never_published(self):
         """
         Test publish confirmation
@@ -377,22 +323,6 @@ class TestSBOMS(TestCase):
                     },
                 ),
                 msg="POST method called incorrectly",
-            )
-
-    def test_sbom_withdraw_with_confirmation(self):
-        """
-        Test sbom withdrawal
-        """
-        with mock.patch.object(
-            self.arch._session, "post"
-        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            mock_get.return_value = MockResponse(200, **WITHDRAWN_RESPONSE)
-            sbom = self.arch.sboms.withdraw(IDENTITY, confirm=True)
-            self.assertEqual(
-                sbom.dict(),
-                WITHDRAWN_RESPONSE,
-                msg="CREATE method called incorrectly",
             )
 
     def test_sbom_withdraw_with_confirmation_never_withdrawn(self):
@@ -506,3 +436,85 @@ class TestSBOMS(TestCase):
                     ),
                     msg="GET method called incorrectly",
                 )
+
+
+class TestSBOMSConfirm(TestCase):
+    """
+    Test Archivist SBOMS Create method with expected confirmation
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        self.arch = Archivist("url", "authauthauth", max_time=100)
+        self.mockstream = BytesIO(b"somelongstring")
+
+    def test_sbom_upload_with_confirmation(self):
+        """
+        Test sbom upload
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE),
+            ]
+            sbom = self.arch.sboms.upload(self.mockstream, confirm=True)
+            self.assertEqual(
+                sbom.dict(),
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_sbom_upload_with_confirmation_and_privacy(self):
+        """
+        Test sbom upload
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(200, **RESPONSE),
+            ]
+            sbom = self.arch.sboms.upload(
+                self.mockstream, confirm=True, params={"privacy": "PUBLIC"}
+            )
+            self.assertEqual(
+                sbom.dict(),
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_sbom_publish_with_confirmation(self):
+        """
+        Test sbom publication
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **PUBLISHED_RESPONSE)
+            sbom = self.arch.sboms.publish(IDENTITY, confirm=True)
+            self.assertEqual(
+                sbom.dict(),
+                PUBLISHED_RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+
+    def test_sbom_withdraw_with_confirmation(self):
+        """
+        Test sbom withdrawal
+        """
+        with mock.patch.object(
+            self.arch._session, "post"
+        ) as mock_post, mock.patch.object(self.arch._session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **WITHDRAWN_RESPONSE)
+            sbom = self.arch.sboms.withdraw(IDENTITY, confirm=True)
+            self.assertEqual(
+                sbom.dict(),
+                WITHDRAWN_RESPONSE,
+                msg="CREATE method called incorrectly",
+            )

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -161,32 +161,6 @@ class TestSubjects(TestCase):
                 msg="CREATE method called incorrectly",
             )
 
-    def test_subjects_create_with_confirmation(self):
-        """
-        Test subjects creation
-        """
-        with mock.patch.object(self.arch._session, "post") as mock_post:
-            mock_post.return_value = MockResponse(200, **RESPONSE)
-            subject = self.arch.subjects.create(
-                DISPLAY_NAME, WALLET_PUB_KEYS, TESSERA_PUB_KEYS
-            )
-            self.assertEqual(
-                subject,
-                RESPONSE,
-                msg="CREATE method called incorrectly",
-            )
-            with mock.patch.object(self.arch._session, "get") as mock_get:
-                mock_get.side_effect = [
-                    MockResponse(200, **RESPONSE),
-                    MockResponse(200, **RESPONSE_WITH_PENDING),
-                    MockResponse(200, **RESPONSE_WITH_CONFIRMATION),
-                ]
-                self.assertEqual(
-                    self.arch.subjects.wait_for_confirmation(subject["identity"]),
-                    RESPONSE_WITH_CONFIRMATION,
-                    msg="wait_for_confirmation called incorrectly",
-                )
-
     def test_subjects_create_with_confirmation_unconfirmed(self):
         """
         Test subjects creation
@@ -450,4 +424,41 @@ class TestSubjects(TestCase):
                         },
                     ),
                     msg="GET method called incorrectly",
+                )
+
+
+class TestSubjectsConfirm(TestCase):
+    """
+    Test Archivist Subjects Create method when confirmation is expected
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        self.arch = Archivist("url", "authauthauth", max_time=100)
+
+    def test_subjects_create_with_confirmation(self):
+        """
+        Test subjects creation
+        """
+        with mock.patch.object(self.arch._session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            subject = self.arch.subjects.create(
+                DISPLAY_NAME, WALLET_PUB_KEYS, TESSERA_PUB_KEYS
+            )
+            self.assertEqual(
+                subject,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+            with mock.patch.object(self.arch._session, "get") as mock_get:
+                mock_get.side_effect = [
+                    MockResponse(200, **RESPONSE),
+                    MockResponse(200, **RESPONSE_WITH_PENDING),
+                    MockResponse(200, **RESPONSE_WITH_CONFIRMATION),
+                ]
+                self.assertEqual(
+                    self.arch.subjects.wait_for_confirmation(subject["identity"]),
+                    RESPONSE_WITH_CONFIRMATION,
+                    msg="wait_for_confirmation called incorrectly",
                 )


### PR DESCRIPTION
Problem:
Sometimes the unittests involving successful upload
fail.

Solution:
For these tests the max_time parameter is too short (1s).
For expected success involving backoff increase max_time to 100s.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>