### PR TITLE
Docs did not publish on release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,6 +20,14 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update
+        sudo apt-get upgrade -y --no-install-recommends
+        sudo apt-get install -y libenchant-2-2
+        sudo apt-get autoremove
+        sudo apt-get autoclean
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
         python3 -m pip install --upgrade pip
         python3 -m pip install build setuptools wheel twine
     - name: Build and publish

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -2,7 +2,10 @@ ARG VERSION=3.7
 FROM python:${VERSION}-bullseye
 
 # Note that any deps installed here must also be installed in the
-# github actions workflow .github/workflows/python-package.yml
+# github actions workflows:
+#
+#      .github/workflows/python-package.yml
+#      .github/workflows/python-publish.yml
 #
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Problem:
The docs did not publish n release because of missing
C dependency.

Solution:
Added dependency installation instructions to the github publish
workflow.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>