### PR TITLE
Docs did not publish on release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,14 +20,6 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        export DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update
-        sudo apt-get upgrade -y --no-install-recommends
-        sudo apt-get install -y libenchant-2-2
-        sudo apt-get autoremove
-        sudo apt-get autoclean
-        sudo apt-get clean
-        sudo rm -rf /var/lib/apt/lists/*
         python3 -m pip install --upgrade pip
         python3 -m pip install build setuptools wheel twine
     - name: Build and publish
@@ -44,6 +36,7 @@ jobs:
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+        pre-build-cmd: "apt-get update && apt-get install -y libenchant-2-2"
     - name: Publish docs
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Problem:
The docs did not publish a release because of missing
C dependency.

Solution:
Added pre-build-cmd installation instructions to the github publish
workflow.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>