### PR TITLE
Docs did not publish on release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-        pre-build-command: "apt-get update && apt-get install -y libenchant-2-2"
+        pre-build-command: "apt-get install -y libenchant-2-2"
     - name: Publish docs
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Problem:
The docs did not publish a release because of a buggy github action.

Solution:
Removed apt-get update from pre-build-cmd in action.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>