### PR TITLE
Docs did not publish on release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,16 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update
+        sudo apt-get upgrade -y --no-install-recommends
+        sudo apt-get install -y libenchant-2-2
+        sudo apt-get autoremove
+        sudo apt-get autoclean
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
         python3 -m pip install --upgrade pip
+        python3 -m pip install -r requirements-dev.txt
         python3 -m pip install build setuptools wheel twine
     - name: Build and publish
       env:
@@ -33,10 +42,10 @@ jobs:
         twine check dist/*
         twine upload dist/*
     - name: Build docs
-      uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "docs/"
-        pre-build-command: "apt-get install -y libenchant-2-2"
+      run: |
+        ls -l
+        cd ./docs
+        make html
     - name: Publish docs
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Problem:
The docs did not publish a release because of a buggy github action.

Solution:
Removed action and attempt to do it manually.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>