### PR TITLE
Skip functional tests conditinally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -159,11 +159,26 @@ export TEST_CLIENT_SECRET_FILENAME=
 export TEST_CLIENT_SECRET="ey.....................ab=="
 task functests
 ```
-Lastly when running the runner tests one can specify a namespace to isolate instances of assets in differnt 
+When running the runner tests one can specify a namespace to isolate instances of assets in differnt 
 runs:
 ```bash
 export ARCHIVIST_NAMESPACE=${RANDOM}
 FUNCTEST=execrunner task functests
+```
+
+Additional environment variables:
+
+For testing sharing via an access policy requires a second auth token:
+
+```bash
+TEST_AUTHTOKEN_FILENAME_2=
+```
+
+Testing of the client token refresh logic can take 10 to 20 minutes to complete.
+To enable this test set:
+
+```bash
+TEST_REFRESH_TOKEN=anything
 ```
 
 #### Testing Other Python Versions

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -4,7 +4,7 @@ Test access_policies
 
 from copy import deepcopy
 from os import getenv
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from uuid import uuid4
 
 from archivist.archivist import Archivist
@@ -115,6 +115,10 @@ class TestAccessPoliciesSimple(TestAccessPoliciesBase):
         )
 
 
+@skipIf(
+    getenv("TEST_AUTHTOKEN_FILENAME_2") is None,
+    "cannot run test as TEST_AUTHTOKEN_FILENAME_2 is not set",
+)
 class TestAccessPolicies(TestAccessPoliciesBase):
     """
     Test Archivist AccessPolicies Create method

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from json import dumps as json_dumps
 from os import getenv
 from time import sleep
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from uuid import uuid4
 
 from archivist.archivist import Archivist
@@ -136,6 +136,10 @@ class TestApplications(TestCase):
         """
         Test application list
         """
+        application = self.arch.applications.create(
+            self.display_name,
+            CUSTOM_CLAIMS,
+        )
         applications = list(self.arch.applications.list(display_name=self.display_name))
         self.assertGreater(
             len(applications),
@@ -193,6 +197,10 @@ class TestApplications(TestCase):
                 client_secret,
             )
 
+    @skipIf(
+        getenv("TEST_REFRESH_TOKEN") is None,
+        "cannot run test as TEST_REFRESH_TOKEN is not set",
+    )
     def test_archivist_token(self):
         """
         Test archivist with client id/secret

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -22,5 +22,6 @@ docker run \
     -e TEST_CLIENT_SECRET \
     -e TEST_CLIENT_SECRET_FILENAME \
     -e TEST_DEBUG \
+    -e TEST_REFRESH_TOKEN \
     jitsuin-archivist-python-builder \
     "$@"


### PR DESCRIPTION
Problem:
Some functional tests either take a long time or
require extra information.

Solution:
TEST_REFRESH_TOKEN=anything will enable the longrunning
refresh token test.
TEST_AUTHTOKEN_FILENAME_2 ewill enable tha access poicy sharing
test if set.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>