### PR TITLE
SBOM metadata has tenantid field

### DIFF
--- a/archivist/sbommetadata.py
+++ b/archivist/sbommetadata.py
@@ -35,6 +35,7 @@ class SBOM:
     withdrawn_date: str
     published_date: str
     rkvst_link: str = ""
+    tenantid: str = ""
 
     def dict(self):
         """Emit dictionary representation"""

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -47,6 +47,7 @@ PROPS = {
     "published_date": "",
     "withdrawn_date": "",
     "rkvst_link": "",
+    "tenantid": "",
 }
 PUBLISHED_PROPS = {**PROPS, **{"published_date": "2021-11-11T17:02:06Z"}}
 WITHDRAWN_PROPS = {**PROPS, **{"withdrawn_date": "2021-11-11T17:02:06Z"}}


### PR DESCRIPTION
Problem:
Tenant ID was added to the SBOM metadata and this emits
an error.

Solution:
Added tenantid to SBOM dataclass and modified unittest accordingly.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>