### PR TITLE
Access policies count_matching methods

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -129,6 +129,7 @@ class _AccessPoliciesClient:
     def update(
         self,
         identity,
+        *,
         props: Optional[Dict] = None,
         filters: Optional[List] = None,
         access_permissions: Optional[List] = None,
@@ -228,22 +229,6 @@ class _AccessPoliciesClient:
         )
 
     # additional queries on different endpoints
-    def count_matching_assets(self, access_policy_id: str) -> int:
-        """Count assets that match access_policy.
-
-        Counts number of assets that match an access_policy.
-
-        Args:
-            access_policy_id (str): e.g. access_policies/xxxxxxxxxxxxxxx
-
-        Returns:
-            integer count of assets.
-
-        """
-        return self._archivist.count(
-            f"{self._subpath}/{access_policy_id}/{ASSETS_LABEL}"
-        )
-
     def list_matching_assets(
         self, access_policy_id: str, *, page_size: Optional[int] = None
     ):
@@ -266,22 +251,6 @@ class _AccessPoliciesClient:
                 ASSETS_LABEL,
                 page_size=page_size,
             )
-        )
-
-    def count_matching_access_policies(self, asset_id: str) -> int:
-        """Count access policies that match asset.
-
-        Counts number of access policies that match asset.
-
-        Args:
-            asset_id (str): e.g. assets/xxxxxxxxxxxxxxx
-
-        Returns:
-            integer count of access policies.
-
-        """
-        return self._archivist.count(
-            f"{self._subpath}/{asset_id}/{ACCESS_POLICIES_LABEL}"
         )
 
     def list_matching_access_policies(

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -196,7 +196,7 @@ class TestAccessPolicies(TestCase):
 
             access_policy = self.arch.access_policies.update(
                 IDENTITY,
-                PROPS,
+                props=PROPS,
             )
             args, kwargs = mock_patch.call_args
             self.assertEqual(
@@ -381,46 +381,6 @@ class TestAccessPolicies(TestCase):
                     msg="GET method called incorrectly",
                 )
 
-    def test_access_policies_count_matching_access_policies(self):
-        """
-        Test access_policy counting
-        """
-        with mock.patch.object(self.arch.session, "get") as mock_get:
-            mock_get.return_value = MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 1},
-                access_policies=[
-                    RESPONSE,
-                ],
-            )
-
-            count = self.arch.access_policies.count_matching_access_policies(ASSET_ID)
-            self.assertEqual(
-                tuple(mock_get.call_args),
-                (
-                    (
-                        (
-                            f"url/{ROOT}/"
-                            f"{ACCESS_POLICIES_SUBPATH}/{ASSET_ID}/{ACCESS_POLICIES_LABEL}"
-                        ),
-                    ),
-                    {
-                        "headers": {
-                            "authorization": "Bearer authauthauth",
-                            HEADERS_REQUEST_TOTAL_COUNT: "true",
-                        },
-                        "params": {"page_size": 1},
-                        "verify": True,
-                    },
-                ),
-                msg="GET method called incorrectly",
-            )
-            self.assertEqual(
-                count,
-                1,
-                msg="Incorrect count",
-            )
-
     def test_access_policies_list_matching_access_policies(self):
         """
         Test access_policy counting
@@ -466,45 +426,6 @@ class TestAccessPolicies(TestCase):
                     ),
                     msg="GET method called incorrectly",
                 )
-
-    def test_access_policies_count_matching_assets(self):
-        """
-        Test access_policy counting
-        """
-        with mock.patch.object(self.arch.session, "get") as mock_get:
-            mock_get.return_value = MockResponse(
-                200,
-                headers={HEADERS_TOTAL_COUNT: 1},
-                assets=[
-                    ASSET,
-                ],
-            )
-
-            count = self.arch.access_policies.count_matching_assets(IDENTITY)
-            self.assertEqual(
-                tuple(mock_get.call_args),
-                (
-                    (
-                        (
-                            f"url/{ROOT}/{ACCESS_POLICIES_SUBPATH}/{IDENTITY}/{ASSETS_LABEL}"
-                        ),
-                    ),
-                    {
-                        "headers": {
-                            "authorization": "Bearer authauthauth",
-                            HEADERS_REQUEST_TOTAL_COUNT: "true",
-                        },
-                        "params": {"page_size": 1},
-                        "verify": True,
-                    },
-                ),
-                msg="GET method called incorrectly",
-            )
-            self.assertEqual(
-                count,
-                1,
-                msg="Incorrect count",
-            )
 
     def test_access_policies_list_matching_assets(self):
         """


### PR DESCRIPTION
Problem:
The backend does not support counting of matching assets or
access_policies in the access_policy endpoint.

Solution:
Removed count_matching_assets() and count_matching_access_polices()
methods in access_policies endpoint.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>