### PR TITLE
Confirm by default

### DIFF
--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -116,7 +116,7 @@ class _AssetsRestricted(_AssetsPublic):
         *,
         props: Optional[Dict] = None,
         attrs: Optional[Dict] = None,
-        confirm: bool = False,
+        confirm: bool = True,
     ) -> Asset:
         """Create asset
 
@@ -138,7 +138,7 @@ class _AssetsRestricted(_AssetsPublic):
         data = self.__params(newprops, attrs)
         return self.create_from_data(data, confirm=confirm)
 
-    def create_from_data(self, data: Dict, *, confirm: bool = False) -> Asset:
+    def create_from_data(self, data: Dict, *, confirm: bool = True) -> Asset:
         """Create asset
 
         Creates asset with request body from data stream.
@@ -159,7 +159,7 @@ class _AssetsRestricted(_AssetsPublic):
         return self.wait_for_confirmation(asset["identity"])
 
     def create_if_not_exists(
-        self, data: Dict, *, confirm: bool = False
+        self, data: Dict, *, confirm: bool = True
     ) -> Tuple[Asset, bool]:
         """
         Creates an asset and associated locations and attachments if asset

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -283,7 +283,7 @@ class _EventsRestricted(_EventsPublic):
         attrs: Dict,
         *,
         asset_attrs: Optional[Dict] = None,
-        confirm: bool = False,
+        confirm: bool = True,
     ) -> Event:
         """Create event
 
@@ -308,7 +308,7 @@ class _EventsRestricted(_EventsPublic):
             confirm=confirm,
         )
 
-    def create_from_data(self, asset_id: str, data: Dict, *, confirm=False) -> Event:
+    def create_from_data(self, asset_id: str, data: Dict, *, confirm=True) -> Event:
         """Create event
 
         Creates event for given asset from data.

--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -183,7 +183,7 @@ class _SBOMSClient:
             with open(filename, "rb") as fd:
                 sbom = self.upload(
                     fd,
-                    confirm=data.get("confirm", False),
+                    confirm=data.get("confirm", True),
                     mtype=data.get("content_type"),
                     params=data.get("params"),
                 )
@@ -194,7 +194,7 @@ class _SBOMSClient:
             get_url(url, fd)
             sbom = self.upload(
                 fd,
-                confirm=data.get("confirm", False),
+                confirm=data.get("confirm", True),
                 mtype=data.get("content_type"),
                 params=data.get("params"),
             )
@@ -218,7 +218,7 @@ class _SBOMSClient:
         self,
         fd: BinaryIO,
         *,
-        confirm: bool = False,
+        confirm: bool = True,
         mtype: Optional[str] = None,
         params: Optional[Dict] = None,
     ) -> SBOM:
@@ -345,7 +345,7 @@ class _SBOMSClient:
             )
         )
 
-    def publish(self, identity: str, confirm: bool = False) -> SBOM:
+    def publish(self, identity: str, confirm: bool = True) -> SBOM:
         """Publish SBOMt
 
         Makes an SBOM public.
@@ -386,7 +386,7 @@ class _SBOMSClient:
         # pylint: disable=protected-access
         return publisher._wait_for_publication(self, identity)  # type: ignore
 
-    def withdraw(self, identity: str, confirm: bool = False) -> SBOM:
+    def withdraw(self, identity: str, confirm: bool = True) -> SBOM:
         """Withdraw SBOM
 
         Withdraws an SBOM.

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -103,6 +103,7 @@ class TestSBOMS(TestCase):
                     "component": "spdx-test-component",
                     "version": "v0.0.1",
                 },
+                confirm=False,
             )
             args, kwargs = mock_post.call_args
             self.assertEqual(
@@ -185,7 +186,10 @@ class TestSBOMS(TestCase):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.sboms.upload(self.mockstream)
+            sbom = self.arch.sboms.upload(
+                self.mockstream,
+                confirm=False,
+            )
             args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,
@@ -356,7 +360,7 @@ class TestSBOMS(TestCase):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.sboms.publish(IDENTITY)
+            sbom = self.arch.sboms.publish(IDENTITY, confirm=False)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (
@@ -399,7 +403,7 @@ class TestSBOMS(TestCase):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.sboms.withdraw(IDENTITY)
+            sbom = self.arch.sboms.withdraw(IDENTITY, confirm=False)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (


### PR DESCRIPTION
Problem:
Assets, events and SBOMs are not confirmed by default.

Solution:
Set default value of confirm to True for assets, events and SBOMs.
Modify unittests.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>