### PR TITLE
Unexpected response fields.

### DIFF
--- a/archivist/sbommetadata.py
+++ b/archivist/sbommetadata.py
@@ -6,6 +6,7 @@
 # pylint:disable=too-many-instance-attributes
 
 from dataclasses import dataclass, asdict
+from inspect import signature as inspect_signature
 from logging import getLogger
 from typing import List
 
@@ -41,3 +42,12 @@ class SBOM:
         """Emit dictionary representation"""
         d = asdict(self)
         return d
+
+    @classmethod
+    def from_dict(cls, indict):
+        """Ignore unexpected fields"""
+        params = inspect_signature(cls).parameters
+        diff = set(indict) - set(params)
+        if diff:
+            LOGGER.info("WARN: extra keys %s ignored", diff)
+        return cls(**{k: indict[k] for k in params})

--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -241,8 +241,8 @@ class _SBOMSClient:
 
         LOGGER.debug("Upload SBOM %s", params)
 
-        sbom = SBOM(
-            **self._archivist.post_file(
+        sbom = SBOM.from_dict(
+            self._archivist.post_file(
                 self._label,
                 fd,
                 mtype,
@@ -300,8 +300,8 @@ class _SBOMSClient:
             BOM
 
         """
-        return SBOM(
-            **self._archivist.get(f"{self._subpath}/{identity}/{SBOMS_METADATA}")
+        return SBOM.from_dict(
+            self._archivist.get(f"{self._subpath}/{identity}/{SBOMS_METADATA}")
         )
 
     def __params(self, metadata: Optional[Dict]) -> Dict:
@@ -336,7 +336,7 @@ class _SBOMSClient:
         """
         params = self.__params(metadata)
         return (
-            SBOM(**a)
+            SBOM.from_dict(a)
             for a in self._archivist.list(
                 f"{self._label}/{SBOMS_WILDCARD}",
                 SBOMS_LABEL,
@@ -359,8 +359,8 @@ class _SBOMSClient:
 
         """
         LOGGER.debug("Publish SBOM %s", identity)
-        sbom = SBOM(
-            **self._archivist.post(
+        sbom = SBOM.from_dict(
+            self._archivist.post(
                 f"{self._subpath}/{identity}:{SBOMS_PUBLISH}",
                 None,
             )
@@ -400,8 +400,8 @@ class _SBOMSClient:
 
         """
         LOGGER.debug("Withdraw SBOM %s", identity)
-        sbom = SBOM(
-            **self._archivist.post(
+        sbom = SBOM.from_dict(
+            self._archivist.post(
                 f"{self._subpath}/{identity}:{SBOMS_WITHDRAW}",
                 None,
             )

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -49,6 +49,7 @@ PROPS = {
     "rkvst_link": "",
     "tenantid": "",
 }
+
 PUBLISHED_PROPS = {**PROPS, **{"published_date": "2021-11-11T17:02:06Z"}}
 WITHDRAWN_PROPS = {**PROPS, **{"withdrawn_date": "2021-11-11T17:02:06Z"}}
 
@@ -57,6 +58,11 @@ SUBPATH = f"{SBOMS_SUBPATH}/{SBOMS_LABEL}"
 RESPONSE = {
     **PROPS,
     "identity": IDENTITY,
+}
+# the extra field should be ignored
+EXTRA_RESPONSE = {
+    **RESPONSE,
+    "extra": "extra",
 }
 PUBLISHED_RESPONSE = {
     **PUBLISHED_PROPS,
@@ -68,16 +74,26 @@ WITHDRAWN_RESPONSE = {
 }
 
 
-class TestSBOMS(TestCase):
+class TestSBOMSBase(TestCase):
     """
-    Test Archivist SBOMS Create method
+    Test Archivist SBOMS
     """
 
     maxDiff = None
 
     def setUp(self):
         self.arch = Archivist("url", "authauthauth", max_time=1)
-        self.mockstream = BytesIO(b"somelongstring")
+
+    def tearDown(self):
+        self.arch = None
+
+
+class TestSBOMS(TestSBOMSBase):
+    """
+    Test Archivist SBOMS Create method
+    """
+
+    maxDiff = None
 
     def test_sboms_str(self):
         """
@@ -88,6 +104,42 @@ class TestSBOMS(TestCase):
             "SBOMSClient(url)",
             msg="Incorrect str",
         )
+
+    def test_sboms_from_dict(self):
+        """
+        Test sboms from_dict
+        """
+        self.assertEqual(
+            SBOM.from_dict(RESPONSE),
+            SBOM(**RESPONSE),
+            msg="Incorrect SBOM",
+        )
+
+    def test_sboms_from_dict_with_extra_field(self):
+        """
+        Test sboms from_dict
+        """
+        self.assertEqual(
+            SBOM.from_dict(EXTRA_RESPONSE),
+            SBOM(**RESPONSE),
+            msg="Incorrect SBOM",
+        )
+
+
+class TestSBOMSUploadDownload(TestSBOMSBase):
+    """
+    Test Archivist SBOMS Upload and Download
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        self.mockstream = BytesIO(b"somelongstring")
+
+    def tearDown(self):
+        super().tearDown()
+        self.mockstream = None
 
     def test_sboms_upload_spdx(self):
         """


### PR DESCRIPTION
Problem:
Endpoints that use dataclasses will throw an uncontrolled exception when
an unexpected field is found in the response. This bug as triggered by
the new tenantid field returned by SBOM endpoint.

Solution:
Added helper function which ignores unexpected fields in SBOM
constructor.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>