### PR TITLE
Miscellaneous fixes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -333,3 +333,29 @@ git log
 git branch -d dev/githubUserHandle/some-proposed-fix
 ```
 
+#### Some notes on adding a new endpoint
+
+Adding a new endpoint will involve the following steps:
+
+(for a new endpoint called widgets...)
+
+- edit archivist/constants.py
+- add archivist/widgets.py
+- add archivist/widget.py
+- edit archivist/runner.py
+- add unittests/testwidget.py
+- add unittests/testwidgets.py
+- add functests/execwidgets.py
+- add functests/test_resources/widgets_story.yaml
+- edit functests/execrunner.py
+- add examples/create_widget.py # and other examples as well
+- add notebooks/'Create Widgets....ipynb' # and other examples
+- add docs/create_widgets.rst
+- edit docs/index.rst
+- edit docs/getting_started.rst
+- add docs/runner/components/widgets.rst
+- edit docs/runner/components/index.rst
+- add docs/runner/demos/widgets.rst
+- edit docs/runner/demos/index.rst
+
+

--- a/README.rst
+++ b/README.rst
@@ -199,13 +199,13 @@ Python
     from sys import exit as sys_exit
     from sys import stdout as sys_stdout
 
-    from archivist import archivist as type_helper
     from archivist import about
+    from archivist.archivist import Archivist
     from archivist.parser import common_parser, endpoint
 
     LOGGER = getLogger(__name__)
 
-    def run(arch: "type_helper.Archivist", args):
+    def run(arch: Archivist, args):
 
         LOGGER.info("Using version %s of jitsuin-archivist", about.__version__)
         LOGGER.info("Namespace %s", args.namespace)

--- a/archivist/compliance.py
+++ b/archivist/compliance.py
@@ -69,7 +69,7 @@ class _ComplianceClient:  # pylint: disable=too-few-public-methods
         self,
         asset_id,
         *,
-        compliant_at: Optional[str] = None,
+        compliant_at: Optional[bool] = None,
         report: Optional[str] = None,
     ) -> Compliance:
         """
@@ -101,7 +101,7 @@ class _ComplianceClient:  # pylint: disable=too-few-public-methods
         Prints report of compliance_at request
 
         Args:
-            response (dict): compliance object encapsulating response from compliant_at
+            compliance (dict): compliance object encapsulating response from compliant_at
         """
 
         LOGGER.info("Compliant %s", compliance["compliant"])

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -8,10 +8,7 @@ from warnings import filterwarnings
 from pyaml_env import parse_config
 
 from archivist import about
-
-# pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from archivist import archivist as type_helper
+from archivist.archivist import Archivist
 
 filterwarnings("ignore", message="Unverified HTTPS request")
 
@@ -19,7 +16,7 @@ filterwarnings("ignore", message="Unverified HTTPS request")
 LOGGER = getLogger(__name__)
 
 
-def run(arch: "type_helper.Archivist", args):
+def run(arch: Archivist, args):
 
     LOGGER.info("Using version %s of jitsuin-archivist", about.__version__)
     LOGGER.info("Namespace %s", args.namespace)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,23 +2,23 @@
 
 # code quality
 autopep8~=1.6
-black~=22.3
-coverage~=6.3
-pip-audit~=2.0
-pycodestyle~=2.8
+black~=22.6
+coverage~=6.4
+pip-audit~=2.4
+pycodestyle~=2.9
 pylint~=2.14
-pyright~=1.1.263
+pyright~=1.1.265
 
 # uploading to pypi
-build~=0.7.0
-twine~=3.8
+build~=0.8
+twine~=4.0
 
 # documentation
 # the file docs/requirements.txt
 # must be kept in sync with this file.
-sphinx~=4.4
+sphinx~=5.1
 sphinx-rtd-theme~=1.0
-sphinxcontrib-spelling~=7.3
+sphinxcontrib-spelling~=7.6
 
 # analyze dependencies
 pipdeptree~=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ flatten-dict~=0.4
 iso8601~=1.0
 Jinja2~=3.0
 pyaml-env~=1.1
-requests~=2.27
+requests~=2.28
 requests-toolbelt~=0.9
 rfc3339~=6.2
-xmltodict~=0.12.0
+xmltodict~=0.13
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "Topic :: Utilities",  # https://pypi.org/classifiers/ # check another option client-sdk
     ],
     install_requires=requirements,
-    version_config={
+    setuptools_git_versioning={
         "template": "{tag}",
         "dev_template": "{tag}.post{ccount}+git.{sha}",
         "dirty_template": "{tag}.post{ccount}+git.{sha}.dirty",
@@ -44,7 +44,7 @@ setup(
         "version_file": None,
         "count_commits_from_version_file": False,
     },
-    setup_requires=["setuptools-git-versioning==1.7.4"],
+    setup_requires=["setuptools-git-versioning"],
     python_requires=">=3.7",
     entry_points={
         "console_scripts": [

--- a/typings/README.md
+++ b/typings/README.md
@@ -1,0 +1,1 @@
+This directory is for pyright typings


### PR DESCRIPTION
Problem:
Miscellaneous fixes.

Solution:
compliance_policies.compliant_at report type hint is bool
example get asset code in README.rst use old type_helper
examples/runner.py also uses type helper incorrectly
typings directory for pyright checking
later version of pyright
Add files to be changed when adding new endpoint
Bump versions in requirements*.txt

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>