### PR TITLE
Make sharing of subject keys easier

### DIFF
--- a/archivist/utils.py
+++ b/archivist/utils.py
@@ -46,6 +46,7 @@ def get_url(url: str, fd: BytesIO):  # pragma no cover
     response = requests_get(
         url,
         stream=True,
+        timeout=30,
     )
 
     for chunk in response.iter_content(chunk_size=4096):

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 
 from archivist.archivist import Archivist
 from archivist.constants import ASSET_BEHAVIOURS
-from archivist.constants import SUBJECTS_SELF_ID
 from archivist.proof_mechanism import ProofMechanism
 from archivist.utils import get_auth
 
@@ -296,24 +295,15 @@ class TestAccessPoliciesShare(TestAccessPoliciesBase):
         self.arch_2 = Archivist(getenv("TEST_ARCHIVIST"), auth_2, verify=False)
 
         # creates reciprocal subjects for arch 1 and arch 2.
-        my_subject_1 = self.arch.subjects.read(SUBJECTS_SELF_ID)
-        my_subject_2 = self.arch_2.subjects.read(SUBJECTS_SELF_ID)
-
         # subject 1 contains details of subject 2 to be shared
-        self.subject_1 = self.arch.subjects.import_subject(
+        self.subject_1, self.subject_2 = self.arch.subjects.share(
             "org2_subject",
-            my_subject_2,
-        )
-
-        # subject 2 contains details of subject 1 to be shared
-        self.subject_2 = self.arch_2.subjects.import_subject(
             "org1_subject",
-            my_subject_1,
+            self.arch_2,
         )
-
-        # check the subjects are confirmed
-        self.arch.subjects.wait_for_confirmation(self.subject_1["identity"])
-        self.arch_2.subjects.wait_for_confirmation(self.subject_2["identity"])
+        print()
+        print("Org1: subject_1", json_dumps(self.subject_1, indent=4))
+        print("Org2: subject_2", json_dumps(self.subject_2, indent=4))
 
     def _create_asset(self, label, arch, uuid):
         asset_data = deepcopy(REQUEST_EXISTS_ATTACHMENTS)

--- a/notebooks/Share_Asset.ipynb
+++ b/notebooks/Share_Asset.ipynb
@@ -111,17 +111,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def import_subject(acme, weyland):\n",
-    "    \"\"\"Add subjects record for weyland in acme's environment\"\"\"\n",
-    "    subject = acme.subjects.import_subject(\n",
-    "        \"weyland\",\n",
-    "        weyland.subjects.read(SUBJECTS_SELF_ID),\n",
-    "    )\n",
-    "\n",
-    "    # must wait for confirmation\n",
-    "    acme.subjects.wait_for_confirmation(subject[\"identity\"])\n",
-    "\n",
-    "    return subject\n"
+    "def share_subjects(name1, arch1, name2, arch2):\n",
+    "    \"\"\"Share subjects between 2 organizations\"\"\"\n",
+    "    return arch1.subjects.share(\n",
+    "        name1,\n",
+    "        name2,\n",
+    "        arch2,\n",
+    "    )"
    ]
   },
   {
@@ -227,8 +223,9 @@
    "source": [
     "# set a subject for weyland in acme's environment. The identity will be used as a\n",
     "# filter in the access permissions of the access_policy.\n",
-    "weyland_subject_on_acme = import_subject(acme, weyland)\n",
-    "print(\"weyland_subject\", json_dumps(weyland_subject_on_acme, indent=4))"
+    "weyland_subject_on_acme, acme_subject_on_weyland = share_subjects(\"weyland on acme\", acme, \"acme_on_weyland\", weyland)\n",
+    "print(\"weyland_subject on acme\", json_dumps(weyland_subject_on_acme, indent=4))\n",
+    "print(\"acme_subject on acme\", json_dumps(acme_subject_on_weyland, indent=4))"
    ]
   },
   {
@@ -306,14 +303,6 @@
     "weyland_asset = weyland.assets.read(acme_asset[\"identity\"])\n",
     "print(\"asset read from weyland\", json_dumps(weyland_asset, indent=4))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2486fd97",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coverage[toml]~=6.4
 pip-audit~=2.4
 pycodestyle~=2.9
 pylint~=2.14
-pyright~=1.1.265
+pyright~=1.1.271
 
 # uploading to pypi
 build~=0.8


### PR DESCRIPTION
Problem:
Sharing of self subject keys is not bidirectional.

Solution:
Add subjects.share() method which efficiently shares self subjects between 2 archivist instances

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>