### PR TITLE
Add new taskfile entry to run functional tests with junit XML output 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage.xml
 .vscode
 stuntidp*
 .npm/
+functest-results/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,7 @@ tasks:
       - ./scripts/builder.sh black archivist examples functests unittests
 
   type-check:
-    desc: Runs the pyright type checker against the core archivst files 
+    desc: Runs the pyright type checker against the core archivst files
     deps: [about]
     cmds:
       - ./scripts/builder.sh pyright archivist
@@ -77,6 +77,12 @@ tasks:
     deps: [about]
     cmds:
       - ./scripts/builder.sh ./scripts/functests.sh
+
+  pipeline-functests:
+    desc: Run functests with Junit xml output
+    deps: [about]
+    cmds:
+      - ./scripts/builder.sh ./scripts/pipeline_functests.sh
 
   notebooks:
     desc: Run jupyter notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ count_commits_from_version_file = false
 
 [tool.pyright]
 include = ["archivist"]
+typeCheckingMode = "basic"
 
 [tool.pylint.main]
 # Analyse import fallback blocks. This can be used to support both Python 2 and 3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pip-audit~=2.4
 pycodestyle~=2.9
 pylint~=2.14
 pyright~=1.1.271
+unittest-xml-reporting~=3.2.0
 
 # uploading to pypi
 build~=0.8

--- a/scripts/pipeline_functests.sh
+++ b/scripts/pipeline_functests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# run functests with xml reporting
+
+rm -rf functest-results
+mkdir -p functest-results
+export PYTHONWARNINGS="ignore:Unverified HTTPS request"
+python -m xmlrunner discover -v -p exec*.py -s functests -o ./functest-results/


### PR DESCRIPTION
Problem:
Functional tests need to be run in the internal RKVST  CI
Solution:
Add new taskfile entry & dependencies that output the results of the functional tests in junit xml
signed-off-by: 
serhiy1@live.co.uk