### PR TITLE
Entrypoint code missing in wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pycodestyle]
-ignore = E128, E203, E225, E265, E266, E402, E501, E713, E722, E741, W503, W504, 
+ignore = E128, E203, E225, E265, E266, E402, E501, E713, E722, E741, W503
 statistics = True
 max-line-length = 88
 
@@ -12,7 +12,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 url = https://github.com/jitsuin-inc/archivist-python
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 
 classifiers =
     Development Status :: 3 - Alpha
@@ -30,7 +30,12 @@ project_urls =
 
 [options]
 install_requires = file: requirements.txt
-packages = archivist
+packages = 
+    archivist
+    archivist.cmds
+    archivist.cmds.runner
+    archivist.cmds.template
+
 platforms = any
 python_requires = >=3.7
 setup_requires = setuptools-git-versioning


### PR DESCRIPTION
Solution:
Explicitly list all cmds subpackages in setup.cfg

Signed-off-by: Paul Hewlett <phwelett76@gmail.com>